### PR TITLE
Fix flatten_arcs collapsing full circles into zero-length segments

### DIFF
--- a/src/clean.cpp
+++ b/src/clean.cpp
@@ -223,7 +223,12 @@ Shape shape::flatten_arcs(
 {
     Shape new_shape = shape;
     for (ShapeElement& element: new_shape.elements) {
+        // A full circle (start == end) is never flat: its chord midpoint
+        // formula degenerates to its start/end point, which trivially lies
+        // on the arc and would otherwise cause it to be misdetected as flat
+        // and collapsed into a zero-length line segment.
         if (element.type == ShapeElementType::CircularArc
+                && element.orientation != ShapeElementOrientation::Full
                 && element.contains((element.start + element.end) / 2)) {
             element.type = ShapeElementType::LineSegment;
         }

--- a/test/clean_test.cpp
+++ b/test/clean_test.cpp
@@ -53,6 +53,53 @@ INSTANTIATE_TEST_SUITE_P(
         });
 
 
+struct FlattenArcsTestParams
+{
+    std::string name;
+    Shape shape;
+    Shape expected_shape;
+};
+
+void PrintTo(const FlattenArcsTestParams& params, std::ostream* os)
+{
+    *os << "shape " << params.shape.to_string(0) << "\n";
+    *os << "expected_shape " << params.expected_shape.to_string(0) << "\n";
+}
+
+class FlattenArcsTest: public testing::TestWithParam<FlattenArcsTestParams> { };
+
+TEST_P(FlattenArcsTest, FlattenArcs)
+{
+    FlattenArcsTestParams test_params = GetParam();
+    Shape output_shape = flatten_arcs(test_params.shape);
+    std::cout << output_shape.to_string(0) << std::endl;
+    EXPECT_EQ(test_params.expected_shape, output_shape);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        ,
+        FlattenArcsTest,
+        testing::ValuesIn(std::vector<FlattenArcsTestParams>{
+            {
+                // A full circle (start == end) must not be flattened into a
+                // zero-length line segment: its chord midpoint formula
+                // degenerates to its start/end point, which trivially lies
+                // on the arc and would otherwise be misdetected as flat.
+                "Circle",
+                build_circle(1.0),
+                build_circle(1.0),
+            }, {
+                // A genuinely curved (non-flat) partial arc must not be
+                // flattened either.
+                "QuarterCircle",
+                build_shape({build_circular_arc({1, 0}, {0, 1}, {0, 0}, ShapeElementOrientation::Anticlockwise)}),
+                build_shape({build_circular_arc({1, 0}, {0, 1}, {0, 0}, ShapeElementOrientation::Anticlockwise)}),
+            }}),
+        [](const testing::TestParamInfo<FlattenArcsTest::ParamType>& info) {
+            return info.param.name;
+        });
+
+
 struct CleanExtremeSlopesOuterTestParams
 {
     std::string name;


### PR DESCRIPTION
A full circle (orientation Full, start == end) was misdetected as flat by flatten_arcs: its chord midpoint formula degenerates to its start/end point, which trivially lies on the arc, so the arc was wrongly converted into a zero-length line segment. This later tripped an assertion in compute_approximation_cost (angle_prev == 0.0) whenever a circle item went through the tree search's directional branching schemes (OpenDimensionX/Y, single-bin BinPackingWithLeftovers/knapsack), since those call shape_simplification, which approximates and simplifies item/bin shapes.