### PR TITLE
Fix intersection wrongly assuming a nested component satisfies all its shapes

### DIFF
--- a/data/tests/boolean_operations/intersection/015.json
+++ b/data/tests/boolean_operations/intersection/015.json
@@ -1,0 +1,35 @@
+{
+  "description": "Two overlapping rectangles A, B (one connected component) plus a third rectangle D nested with no boundary contact strictly inside both. Expected: D itself, since D is fully inside A and B. Currently fails: the nested-component-drop optimization in compute_splitted_elements discards A/B's boundary once D is found nested inside their merged component, without verifying D is really inside every shape of that component, not just one.",
+  "shapes": [
+    {
+      "type": "rectangle",
+      "x": 0,
+      "y": 0,
+      "width": 10,
+      "height": 10
+    },
+    {
+      "type": "rectangle",
+      "x": 5,
+      "y": 0,
+      "width": 10,
+      "height": 10
+    },
+    {
+      "type": "rectangle",
+      "x": 6,
+      "y": 1,
+      "width": 2,
+      "height": 2
+    }
+  ],
+  "expected_output": [
+    {
+      "type": "rectangle",
+      "x": 6,
+      "y": 1,
+      "width": 2,
+      "height": 2
+    }
+  ]
+}

--- a/src/boolean_operations.cpp
+++ b/src/boolean_operations.cpp
@@ -189,6 +189,79 @@ ComponentBridge find_component_bridge(
     return bridge;
 }
 
+/**
+ * Bridge inner_component_id into outer_component_id: connects the two
+ * components into a single planar graph component (as a slit with no area
+ * of its own) so the face-tracing algorithm can walk both boundaries in one
+ * pass. Every shape keeps its real boundary in the arrangement, so
+ * is_inside is computed normally for both components instead of assuming
+ * one of them is trivially satisfied.
+ */
+void bridge_components(
+        ComponentId inner_component_id,
+        ComponentId outer_component_id,
+        const std::vector<ShapeWithHoles>& shapes,
+        std::vector<ShapeElement>& elements,
+        std::vector<ElementToSplit>& elements_info,
+        std::vector<std::vector<Point>>& elements_intersections,
+        optimizationtools::DoublyIndexedMap& shape_component_ids)
+{
+    ComponentBridge bridge = find_component_bridge(
+            inner_component_id,
+            outer_component_id,
+            shapes,
+            elements,
+            elements_info,
+            shape_component_ids);
+
+    ElementPos bridge_pos = elements.size();
+    elements.push_back(bridge.element);
+    {
+        ElementToSplit element_info;
+        element_info.orig_shape_id = bridge.orig_shape_id;
+        elements_info.push_back(element_info);
+    }
+    elements_intersections.push_back({});
+
+    // Compute intersections of the bridge with all existing
+    // elements so planar graph nodes are consistent.
+    for (ElementPos element_pos = 0;
+            element_pos < bridge_pos;
+            ++element_pos) {
+        ShapeElementIntersectionsOutput bridge_intersections
+            = compute_intersections(
+                    bridge.element, elements[element_pos]);
+        for (const ShapeElement& overlapping_part:
+                bridge_intersections.overlapping_parts) {
+            elements_intersections[bridge_pos].push_back(
+                    overlapping_part.start);
+            elements_intersections[bridge_pos].push_back(
+                    overlapping_part.end);
+            elements_intersections[element_pos].push_back(
+                    overlapping_part.start);
+            elements_intersections[element_pos].push_back(
+                    overlapping_part.end);
+        }
+        for (const Point& point:
+                bridge_intersections.proper_intersections) {
+            elements_intersections[bridge_pos].push_back(point);
+            elements_intersections[element_pos].push_back(point);
+        }
+        for (const Point& point:
+                bridge_intersections.improper_intersections) {
+            elements_intersections[bridge_pos].push_back(point);
+            elements_intersections[element_pos].push_back(point);
+        }
+    }
+
+    // Merge inner_component_id into outer_component_id.
+    while (shape_component_ids.number_of_elements(inner_component_id) > 0) {
+        shape_component_ids.set(
+                *shape_component_ids.begin(inner_component_id),
+                outer_component_id);
+    }
+}
+
 
 ComputeSplittedElementsOutput compute_splitted_elements(
         const std::vector<ShapeWithHoles>& shapes,
@@ -373,72 +446,33 @@ ComputeSplittedElementsOutput compute_splitted_elements(
                 }
                 break;
             } case BooleanOperation::Intersection: {
-                while (output.shape_component_ids.number_of_elements(component_2_id) > 0) {
-                    output.shape_component_ids.set(
-                            *output.shape_component_ids.begin(component_2_id),
-                            shapes.size());
-                }
-                break;
-            } case BooleanOperation::Difference: {
-                // component_id is strictly inside component_2_id.
-                // Bridge the two components so the planar graph can represent
-                // the subtractor as a hole in the base.
-                ComponentBridge bridge = find_component_bridge(
+                // component_id is strictly inside component_2_id with no
+                // shared boundary. Bridge them into one arrangement (as for
+                // Difference below) so every shape's real boundary is still
+                // traced and is_inside is computed normally for both
+                // components, instead of assuming component_2_id is
+                // trivially satisfied and dropping it outright.
+                bridge_components(
                         component_id,
                         component_2_id,
                         shapes,
                         elements,
                         elements_info,
+                        elements_intersections,
                         output.shape_component_ids);
-
-                ElementPos bridge_pos = elements.size();
-                elements.push_back(bridge.element);
-                {
-                    ElementToSplit element_info;
-                    element_info.orig_shape_id = bridge.orig_shape_id;
-                    elements_info.push_back(element_info);
-                }
-                elements_intersections.push_back({});
-
-                // Compute intersections of the bridge with all existing
-                // elements so planar graph nodes are consistent.
-                for (ElementPos element_pos = 0;
-                        element_pos < bridge_pos;
-                        ++element_pos) {
-                    ShapeElementIntersectionsOutput bridge_intersections
-                        = compute_intersections(
-                                bridge.element, elements[element_pos]);
-                    for (const ShapeElement& overlapping_part:
-                            bridge_intersections.overlapping_parts) {
-                        elements_intersections[bridge_pos].push_back(
-                                overlapping_part.start);
-                        elements_intersections[bridge_pos].push_back(
-                                overlapping_part.end);
-                        elements_intersections[element_pos].push_back(
-                                overlapping_part.start);
-                        elements_intersections[element_pos].push_back(
-                                overlapping_part.end);
-                    }
-                    for (const Point& point:
-                            bridge_intersections.proper_intersections) {
-                        elements_intersections[bridge_pos].push_back(point);
-                        elements_intersections[element_pos].push_back(point);
-                    }
-                    for (const Point& point:
-                            bridge_intersections.improper_intersections) {
-                        elements_intersections[bridge_pos].push_back(point);
-                        elements_intersections[element_pos].push_back(point);
-                    }
-                }
-
-                // Merge component_id into component_2_id.
-                while (output.shape_component_ids.number_of_elements(
-                        component_id) > 0) {
-                    output.shape_component_ids.set(
-                            *output.shape_component_ids.begin(component_id),
-                            component_2_id);
-                }
-
+                break;
+            } case BooleanOperation::Difference: {
+                // component_id is strictly inside component_2_id.
+                // Bridge the two components so the planar graph can represent
+                // the subtractor as a hole in the base.
+                bridge_components(
+                        component_id,
+                        component_2_id,
+                        shapes,
+                        elements,
+                        elements_info,
+                        elements_intersections,
+                        output.shape_component_ids);
                 break;
             } case BooleanOperation::SymmetricDifference: {
                 throw std::logic_error(

--- a/test/boolean_operations_test.cpp
+++ b/test/boolean_operations_test.cpp
@@ -394,6 +394,8 @@ INSTANTIATE_TEST_SUITE_P(
                     (fs::path("data") / "tests" / "boolean_operations" / "intersection" / "013.json").string()),
             ComputeBooleanIntersectionTestParams::read_json(
                     (fs::path("data") / "tests" / "boolean_operations" / "intersection" / "014.json").string()),
+            ComputeBooleanIntersectionTestParams::read_json(
+                    (fs::path("data") / "tests" / "boolean_operations" / "intersection" / "015.json").string()),
         }),
         [](const testing::TestParamInfo<ComputeBooleanIntersectionTest::ParamType>& info) {
             return fs::path(info.param.name).stem().string();


### PR DESCRIPTION
When computing an N-ary intersection, a shape nested with no boundary contact strictly inside a merged component of overlapping shapes had that whole component's boundary dropped from the arrangement on the assumption it trivially contained the nested shape. That assumption only holds when every shape of the dropped component individually contains the nested one: otherwise the intersection could be silently over- or under-reported.

Bridge the two components into a single arrangement instead (the same technique already used for Difference), so every shape keeps its real boundary and is_inside is computed normally, with no assumption needed.