### PR TITLE
Add MultiShapeWithHoles and use it throughout the boolean-op APIs

### DIFF
--- a/include/shape/boolean_operations.hpp
+++ b/include/shape/boolean_operations.hpp
@@ -8,7 +8,7 @@ namespace shape
 /**
  * Compute the union of a given set of shapes.
  */
-std::vector<ShapeWithHoles> compute_union(
+MultiShapeWithHoles compute_union(
         const std::vector<ShapeWithHoles>& shapes);
 
 void compute_union_export_inputs(
@@ -18,7 +18,7 @@ void compute_union_export_inputs(
 /**
  * Compute the intersection of a given set of shapes.
  */
-std::vector<ShapeWithHoles> compute_intersection(
+MultiShapeWithHoles compute_intersection(
         const std::vector<ShapeWithHoles>& shapes);
 
 void compute_intersection_export_inputs(
@@ -32,22 +32,22 @@ void compute_intersection_export_inputs(
  * the result if it belongs to at least one `ShapeWithHoles` of every
  * multi-shape.
  */
-std::vector<ShapeWithHoles> compute_intersection(
-        const std::vector<std::vector<ShapeWithHoles>>& multi_shapes);
+MultiShapeWithHoles compute_intersection(
+        const std::vector<MultiShapeWithHoles>& multi_shapes);
 
 /**
  * Compute the difference between two multi-shapes.
  */
-std::vector<ShapeWithHoles> compute_difference(
-        const std::vector<ShapeWithHoles>& shapes_1,
-        const std::vector<ShapeWithHoles>& shapes_2);
+MultiShapeWithHoles compute_difference(
+        const MultiShapeWithHoles& shapes_1,
+        const MultiShapeWithHoles& shapes_2);
 
 /**
  * Compute the symmetric difference between two multi-shapes.
  */
-std::vector<ShapeWithHoles> compute_symmetric_difference(
-        const std::vector<ShapeWithHoles>& shapes_1,
-        const std::vector<ShapeWithHoles>& shapes_2);
+MultiShapeWithHoles compute_symmetric_difference(
+        const MultiShapeWithHoles& shapes_1,
+        const MultiShapeWithHoles& shapes_2);
 
 Shape extract_outline(
         const Shape& shape);
@@ -67,7 +67,7 @@ std::vector<ShapeElement> find_holes_bridges(
  * This creates an invalid shape but is a necessary preprocess for the
  * trapezoidation algorithm.
  */
-std::vector<ShapeWithHoles> bridge_touching_holes(
+MultiShapeWithHoles bridge_touching_holes(
         const ShapeWithHoles& shape);
 
 }

--- a/include/shape/clean.hpp
+++ b/include/shape/clean.hpp
@@ -49,7 +49,7 @@ std::vector<Shape> clean_extreme_slopes_inner(
         const Shape& shape);
 
 
-std::vector<ShapeWithHoles> fix_self_intersections(
+MultiShapeWithHoles fix_self_intersections(
         const ShapeWithHoles& shape);
 
 }

--- a/include/shape/no_fit_polygon.hpp
+++ b/include/shape/no_fit_polygon.hpp
@@ -36,9 +36,9 @@ Shape no_fit_polygon(
  * then returns the union of all those convex NFPs.
  *
  * The result may consist of several disconnected components or contain holes,
- * hence the return type is a vector of ShapeWithHoles.
+ * hence the return type is a MultiShapeWithHoles.
  */
-std::vector<ShapeWithHoles> no_fit_polygon(
+MultiShapeWithHoles no_fit_polygon(
         const ShapeWithHoles& fixed_shape,
         const ShapeWithHoles& orbiting_shape);
 

--- a/include/shape/rasterization.hpp
+++ b/include/shape/rasterization.hpp
@@ -48,7 +48,7 @@ Shape cell_to_shape(
 /**
  * Convert a list of cells into shapes with holes.
  */
-std::vector<ShapeWithHoles> cells_to_shapes(
+MultiShapeWithHoles cells_to_shapes(
         const std::vector<Cell>& cells,
         LengthDbl cell_width,
         LengthDbl cell_height);
@@ -56,7 +56,7 @@ std::vector<ShapeWithHoles> cells_to_shapes(
 /**
  * Convert a list of intersected cells into shapes with holes.
  */
-std::vector<ShapeWithHoles> cells_to_shapes(
+MultiShapeWithHoles cells_to_shapes(
         const std::vector<IntersectedCell>& cells,
         LengthDbl cell_width,
         LengthDbl cell_height,

--- a/include/shape/shape.hpp
+++ b/include/shape/shape.hpp
@@ -783,17 +783,42 @@ ShapeWithHoles operator*(
         LengthDbl scalar,
         const ShapeWithHoles& shape);
 
-void shift(
-        std::vector<ShapeWithHoles>& shapes_with_holes,
-        LengthDbl x,
-        LengthDbl y);
-
-inline void shift(
-        std::vector<ShapeWithHoles>& shapes_with_holes,
-        const Point& vector)
+/**
+ * Structure for a set of possibly disjoint shapes with holes, i.e. a
+ * multi-shape, the union of several `ShapeWithHoles`.
+ */
+struct MultiShapeWithHoles
 {
-    shift(shapes_with_holes, vector.x, vector.y);
-}
+    std::vector<ShapeWithHoles> shapes_with_holes;
+
+    MultiShapeWithHoles& shift(
+            LengthDbl x,
+            LengthDbl y);
+
+    MultiShapeWithHoles& shift(
+            const Point& vector)
+    {
+        return this->shift(vector.x, vector.y);
+    }
+
+    /*
+     * Export
+     */
+
+    template <class basic_json>
+    static MultiShapeWithHoles from_json(basic_json& json_shape);
+
+    static MultiShapeWithHoles read_json(
+            const std::string& file_path);
+
+    nlohmann::json to_json() const;
+
+    void write_json(
+            const std::string& file_path) const;
+
+    std::string to_svg(
+            const std::string& fill_color = "blue") const;
+};
 
 struct BuildShapeElement
 {
@@ -969,6 +994,16 @@ ShapeWithHoles ShapeWithHoles::from_json(basic_json& json_shape)
     }
 
     return shape;
+}
+
+template <class basic_json>
+MultiShapeWithHoles MultiShapeWithHoles::from_json(basic_json& json_shape)
+{
+    MultiShapeWithHoles multi_shape;
+    for (auto& json_shape_with_holes: json_shape.items())
+        multi_shape.shapes_with_holes.push_back(
+                ShapeWithHoles::from_json(json_shape_with_holes.value()));
+    return multi_shape;
 }
 
 }

--- a/src/approximation.cpp
+++ b/src/approximation.cpp
@@ -385,7 +385,7 @@ ShapeWithHoles shape::approximate_shape_by_line_segments(
     }
 
     //Writer().add_shapes_with_holes(union_input).write_json("union_input.json");
-    std::vector<ShapeWithHoles> union_output = compute_union(union_input);
+    std::vector<ShapeWithHoles> union_output = compute_union(union_input).shapes_with_holes;
     return union_output.front();
 }
 
@@ -555,7 +555,7 @@ ShapeWithHoles shape::approximate_by_line_segments(
         shape_new.holes.push_back(hole_new);
     }
 
-    std::vector<ShapeWithHoles> union_output = compute_union(union_input);
+    std::vector<ShapeWithHoles> union_output = compute_union(union_input).shapes_with_holes;
 #ifdef APPROXIMATE_ENABLE_DEBUG
     Writer()
         .add_shape_with_holes(shape_orig, "Input shape")

--- a/src/boolean_operations.cpp
+++ b/src/boolean_operations.cpp
@@ -1367,7 +1367,7 @@ std::vector<ShapeWithHoles> compute_boolean_operation_component(
     }
 
     if (boolean_operation == BooleanOperation::Union)
-        new_shapes = fix_self_intersections(new_shapes[0]);
+        new_shapes = fix_self_intersections(new_shapes[0]).shapes_with_holes;
 
     return new_shapes;
 }
@@ -1494,7 +1494,7 @@ std::vector<ShapeWithHoles> compute_boolean_operation(
 
 }
 
-std::vector<ShapeWithHoles> shape::compute_union(
+MultiShapeWithHoles shape::compute_union(
         const std::vector<ShapeWithHoles>& shapes)
 {
     //std::cout << "compute_union " << shapes.size() << std::endl;
@@ -1502,9 +1502,9 @@ std::vector<ShapeWithHoles> shape::compute_union(
     //        "compute_union_inputs.json",
     //        shapes);
 
-    return compute_boolean_operation(
+    return {compute_boolean_operation(
             shapes,
-            BooleanOperation::Union);
+            BooleanOperation::Union)};
 }
 
 void shape::compute_union_export_inputs(
@@ -1521,7 +1521,7 @@ void shape::compute_union_export_inputs(
     file << std::setw(4) << json << std::endl;
 }
 
-std::vector<ShapeWithHoles> shape::compute_intersection(
+MultiShapeWithHoles shape::compute_intersection(
         const std::vector<ShapeWithHoles>& shapes)
 {
     std::vector<ShapeWithHoles> faces = compute_boolean_operation(
@@ -1544,13 +1544,13 @@ void shape::compute_intersection_export_inputs(
     file << std::setw(4) << json << std::endl;
 }
 
-std::vector<ShapeWithHoles> shape::compute_intersection(
-        const std::vector<std::vector<ShapeWithHoles>>& multi_shapes)
+MultiShapeWithHoles shape::compute_intersection(
+        const std::vector<MultiShapeWithHoles>& multi_shapes)
 {
     // An empty multi-shape represents an empty region: intersecting with it
     // always yields an empty result.
-    for (const std::vector<ShapeWithHoles>& multi_shape: multi_shapes)
-        if (multi_shape.empty())
+    for (const MultiShapeWithHoles& multi_shape: multi_shapes)
+        if (multi_shape.shapes_with_holes.empty())
             return {};
 
     std::vector<ShapeWithHoles> shapes;
@@ -1558,7 +1558,7 @@ std::vector<ShapeWithHoles> shape::compute_intersection(
     for (ShapePos group_id = 0;
             group_id < (ShapePos)multi_shapes.size();
             ++group_id) {
-        for (const ShapeWithHoles& shape: multi_shapes[group_id]) {
+        for (const ShapeWithHoles& shape: multi_shapes[group_id].shapes_with_holes) {
             shapes.push_back(shape);
             group_ids.push_back(group_id);
         }
@@ -1572,29 +1572,29 @@ std::vector<ShapeWithHoles> shape::compute_intersection(
     return compute_union(faces);
 }
 
-std::vector<ShapeWithHoles> shape::compute_difference(
-        const std::vector<ShapeWithHoles>& shapes_1,
-        const std::vector<ShapeWithHoles>& shapes_2)
+MultiShapeWithHoles shape::compute_difference(
+        const MultiShapeWithHoles& shapes_1,
+        const MultiShapeWithHoles& shapes_2)
 {
-    std::vector<ShapeWithHoles> v = shapes_1;
-    v.insert(v.end(), shapes_2.begin(), shapes_2.end());
+    std::vector<ShapeWithHoles> v = shapes_1.shapes_with_holes;
+    v.insert(v.end(), shapes_2.shapes_with_holes.begin(), shapes_2.shapes_with_holes.end());
     std::vector<ShapeWithHoles> faces = compute_boolean_operation(
             v,
             BooleanOperation::Difference,
-            shapes_1.size());
+            shapes_1.shapes_with_holes.size());
     return compute_union(faces);
 }
 
-std::vector<ShapeWithHoles> shape::compute_symmetric_difference(
-        const std::vector<ShapeWithHoles>& shapes_1,
-        const std::vector<ShapeWithHoles>& shapes_2)
+MultiShapeWithHoles shape::compute_symmetric_difference(
+        const MultiShapeWithHoles& shapes_1,
+        const MultiShapeWithHoles& shapes_2)
 {
-    std::vector<ShapeWithHoles> v = shapes_1;
-    v.insert(v.end(), shapes_2.begin(), shapes_2.end());
+    std::vector<ShapeWithHoles> v = shapes_1.shapes_with_holes;
+    v.insert(v.end(), shapes_2.shapes_with_holes.begin(), shapes_2.shapes_with_holes.end());
     std::vector<ShapeWithHoles> faces = compute_boolean_operation(
             v,
             BooleanOperation::SymmetricDifference,
-            shapes_1.size());
+            shapes_1.shapes_with_holes.size());
     return compute_union(faces);
 }
 
@@ -1773,7 +1773,7 @@ std::vector<ShapeElement> shape::find_holes_bridges(
     return bridges;
 }
 
-std::vector<ShapeWithHoles> shape::bridge_touching_holes(
+MultiShapeWithHoles shape::bridge_touching_holes(
         const ShapeWithHoles& shape)
 {
     HoleGraph hole_graph = compute_hole_graph(shape);
@@ -1788,7 +1788,7 @@ std::vector<ShapeWithHoles> shape::bridge_touching_holes(
     std::vector<ShapeWithHoles> faces = compute_boolean_operation(
             v,
             BooleanOperation::Difference);
-    std::vector<ShapeWithHoles> output;
+    MultiShapeWithHoles output;
     for (const ShapeWithHoles& face: faces) {
         ShapeWithHoles shape_with_holes = face;
         for (ShapePos hole_pos = 0;
@@ -1800,7 +1800,7 @@ std::vector<ShapeWithHoles> shape::bridge_touching_holes(
             if (face.contains(hole.find_point_strictly_inside(), true))
                 shape_with_holes.holes.push_back(hole);
         }
-        output.push_back(shape_with_holes);
+        output.shapes_with_holes.push_back(shape_with_holes);
     }
     return output;
 }

--- a/src/clean.cpp
+++ b/src/clean.cpp
@@ -834,7 +834,7 @@ ShapeWithHoles shape::clean_extreme_slopes_outer(
         std::vector<ShapeWithHoles> shapes_to_union = {{shape_orig}};
         for (const Shape& triangle: triangles_added)
             shapes_to_union.push_back({triangle});
-        std::vector<ShapeWithHoles> u = compute_union(shapes_to_union);
+        std::vector<ShapeWithHoles> u = compute_union(shapes_to_union).shapes_with_holes;
         return u.front();
     }
 
@@ -885,8 +885,8 @@ std::vector<Shape> shape::clean_extreme_slopes_inner(
         for (const Shape& triangle: triangles_removed)
             triangles_removed_swh.push_back({triangle});
         std::vector<ShapeWithHoles> difference = compute_difference(
-                {{shape_orig}},
-                triangles_removed_swh);
+                MultiShapeWithHoles{{{shape_orig}}},
+                MultiShapeWithHoles{triangles_removed_swh}).shapes_with_holes;
 
         std::vector<Shape> output;
         for (const ShapeWithHoles& shape_with_holes: difference)
@@ -910,19 +910,20 @@ std::vector<Shape> shape::clean_extreme_slopes_inner(
     return {shape};
 }
 
-std::vector<ShapeWithHoles> shape::fix_self_intersections(
+MultiShapeWithHoles shape::fix_self_intersections(
         const ShapeWithHoles& shape)
 {
     //std::cout << "fix_self_intersections" << std::endl;
     //Writer().add_shape_with_holes(shape).write_json("fix_self_intersections_input.json");
-    std::vector<ShapeWithHoles> shapes = bridge_touching_holes(shape);
+    std::vector<ShapeWithHoles> shapes = bridge_touching_holes(shape).shapes_with_holes;
     if (shapes.size() == 1)
-        return {shape};
-    std::vector<ShapeWithHoles> output(shapes.size());
+        return {{shape}};
+    MultiShapeWithHoles output;
+    output.shapes_with_holes.resize(shapes.size());
     for (ShapePos shape_pos = 0;
             shape_pos < (ShapePos)shapes.size();
             ++shape_pos) {
-        output[shape_pos] = compute_union({shapes[shape_pos]}).front();
+        output.shapes_with_holes[shape_pos] = compute_union({shapes[shape_pos]}).shapes_with_holes.front();
     }
     return output;
 }

--- a/src/no_fit_polygon.cpp
+++ b/src/no_fit_polygon.cpp
@@ -163,7 +163,7 @@ Shape shape::no_fit_polygon(
     return remove_aligned_vertices(result).second;
 }
 
-std::vector<ShapeWithHoles> shape::no_fit_polygon(
+MultiShapeWithHoles shape::no_fit_polygon(
         const ShapeWithHoles& fixed_shape,
         const ShapeWithHoles& orbiting_shape)
 {

--- a/src/offset.cpp
+++ b/src/offset.cpp
@@ -343,7 +343,7 @@ ShapeWithHoles shape::inflate(
     compute_union_export_inputs("compute_union_input.json", union_input);
     Writer().add_shapes_with_holes(union_input).write_json("shapes.json");
 #endif
-    return compute_union(union_input).front();
+    return compute_union(union_input).shapes_with_holes.front();
 }
 
 ShapeWithHoles shape::inflate(
@@ -533,7 +533,7 @@ ShapeWithHoles shape::inflate(
     compute_union_export_inputs("union_input.json", union_input);
     Writer().add_shape(shape_orig).add_shapes_with_holes(union_input).write_json("shapes.json");
 #endif
-    return compute_union(union_input).front();
+    return compute_union(union_input).shapes_with_holes.front();
 }
 
 std::vector<Shape> shape::deflate(
@@ -619,9 +619,11 @@ std::vector<Shape> shape::deflate(
         element_prev_pos = element_pos;
     }
 
-    auto difference_output = compute_difference(std::vector<ShapeWithHoles>{{shape}}, difference_input);
+    auto difference_output = compute_difference(
+            MultiShapeWithHoles{{{shape}}},
+            MultiShapeWithHoles{difference_input});
     std::vector<Shape> output;
-    for (const ShapeWithHoles& shape: difference_output)
+    for (const ShapeWithHoles& shape: difference_output.shapes_with_holes)
         output.push_back(shape.shape);
     return output;
 }

--- a/src/rasterization.cpp
+++ b/src/rasterization.cpp
@@ -308,7 +308,7 @@ Shape shape::cell_to_shape(
             {(cell.column + 1) * cell_width, (cell.row + 1) * cell_height});
 }
 
-std::vector<ShapeWithHoles> shape::cells_to_shapes(
+MultiShapeWithHoles shape::cells_to_shapes(
         const std::vector<Cell>& cells,
         LengthDbl cell_width,
         LengthDbl cell_height)
@@ -319,7 +319,7 @@ std::vector<ShapeWithHoles> shape::cells_to_shapes(
     return compute_union(union_input);
 }
 
-std::vector<ShapeWithHoles> shape::cells_to_shapes(
+MultiShapeWithHoles shape::cells_to_shapes(
         const std::vector<IntersectedCell>& cells,
         LengthDbl cell_width,
         LengthDbl cell_height,

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -2353,13 +2353,62 @@ ShapeWithHoles shape::operator*(
     return shape_new;
 }
 
-void shift(
-        std::vector<ShapeWithHoles>& shapes_with_holes,
+MultiShapeWithHoles& MultiShapeWithHoles::shift(
         LengthDbl x,
         LengthDbl y)
 {
-    for (ShapeWithHoles& shape_with_holes: shapes_with_holes)
+    for (ShapeWithHoles& shape_with_holes: this->shapes_with_holes)
         shape_with_holes.shift(x, y);
+    return *this;
+}
+
+MultiShapeWithHoles MultiShapeWithHoles::read_json(
+        const std::string& file_path)
+{
+    std::ifstream file(file_path);
+    if (!file.good()) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + ": "
+                "unable to open file \"" + file_path + "\".");
+    }
+    nlohmann::json j;
+    file >> j;
+    return from_json(j);
+}
+
+nlohmann::json MultiShapeWithHoles::to_json() const
+{
+    nlohmann::json json;
+    for (Counter shape_pos = 0;
+            shape_pos < (Counter)this->shapes_with_holes.size();
+            ++shape_pos) {
+        json[shape_pos] = this->shapes_with_holes[shape_pos].to_json();
+    }
+    return json;
+}
+
+void MultiShapeWithHoles::write_json(
+        const std::string& file_path) const
+{
+    if (file_path.empty())
+        return;
+    std::ofstream file{file_path};
+    if (!file.good()) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + ": "
+                "unable to open file \"" + file_path + "\".");
+    }
+    nlohmann::json json = this->to_json();
+    file << std::setw(4) << json << std::endl;
+}
+
+std::string MultiShapeWithHoles::to_svg(
+        const std::string& fill_color) const
+{
+    std::string s;
+    for (const ShapeWithHoles& shape_with_holes: this->shapes_with_holes)
+        s += shape_with_holes.to_svg(fill_color);
+    return s;
 }
 
 bool shape::operator==(

--- a/src/shapes_intersections.cpp
+++ b/src/shapes_intersections.cpp
@@ -1057,7 +1057,7 @@ bool shape::intersect(
         return false;
     }
 
-    return !compute_intersection({shape_with_holes_1, shape_with_holes_2}).empty();
+    return !compute_intersection({shape_with_holes_1, shape_with_holes_2}).shapes_with_holes.empty();
 }
 
 void shape::intersect_export_inputs(

--- a/src/simplification.cpp
+++ b/src/simplification.cpp
@@ -949,7 +949,7 @@ std::vector<ShapeWithHoles> shape::simplify(
             }
         }
         if (fix || intersect(shapes_new[shape_pos]))
-            shapes_new[shape_pos] = compute_union(union_inputs[shape_pos]).front();
+            shapes_new[shape_pos] = compute_union(union_inputs[shape_pos]).shapes_with_holes.front();
     }
 
     // Check output.

--- a/src/trapezoidation.cpp
+++ b/src/trapezoidation.cpp
@@ -181,7 +181,7 @@ std::vector<GeneralizedTrapezoid> shape::trapezoidation(
     //std::cout << "polygon_trapezoidation" << std::endl;
     //std::cout << shape.to_string(0) << std::endl;
     //write_json({shape}, {}, "trapezoidation_input.json");
-    ShapeWithHoles shape = bridge_touching_holes(shape_orig).front();
+    ShapeWithHoles shape = bridge_touching_holes(shape_orig).shapes_with_holes.front();
     //std::cout << shape.to_string(0) << std::endl;
 
     std::vector<GeneralizedTrapezoid> trapezoids;

--- a/test/boolean_operations_test.cpp
+++ b/test/boolean_operations_test.cpp
@@ -205,7 +205,7 @@ TEST_P(ComputeBooleanUnionTest, ComputeBooleanUnion)
         }
     }
     auto output = compute_union(
-            test_params.shapes);
+            test_params.shapes).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << "- " << shape.to_string(2) << std::endl;
@@ -341,7 +341,7 @@ TEST_P(ComputeBooleanIntersectionTest, ComputeBooleanIntersection)
 #endif
 
     auto output = compute_intersection(
-            test_params.shapes);
+            test_params.shapes).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << "- " << shape.to_string(2) << std::endl;
@@ -405,7 +405,7 @@ INSTANTIATE_TEST_SUITE_P(
 struct ComputeBooleanIntersectionMultiShapeTestParams
 {
     std::string name;
-    std::vector<std::vector<ShapeWithHoles>> multi_shapes;
+    std::vector<MultiShapeWithHoles> multi_shapes;
     std::vector<ShapeWithHoles> expected_output;
 };
 
@@ -417,7 +417,7 @@ void PrintTo(const ComputeBooleanIntersectionMultiShapeTestParams& params, std::
             group_pos < (Counter)params.multi_shapes.size();
             ++group_pos) {
         *os << "group " << group_pos << "\n";
-        for (const ShapeWithHoles& shape: params.multi_shapes[group_pos])
+        for (const ShapeWithHoles& shape: params.multi_shapes[group_pos].shapes_with_holes)
             *os << "- " << shape.to_string(2) << "\n";
     }
     *os << "expected_output\n";
@@ -433,7 +433,7 @@ TEST_P(ComputeBooleanIntersectionMultiShapeTest, ComputeBooleanIntersectionMulti
     PrintTo(test_params, &std::cout);
 
     auto output = compute_intersection(
-            test_params.multi_shapes);
+            test_params.multi_shapes).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << "- " << shape.to_string(2) << std::endl;
@@ -456,12 +456,12 @@ INSTANTIATE_TEST_SUITE_P(
                // which overlap the other group.
                 "TwoGroupsWithDisjointPieces",
                 {
-                    {
+                    MultiShapeWithHoles{{
                         {build_rectangle(0, 2, 0, 1)},
                         {build_rectangle(10, 12, 0, 1)},
-                    }, {
+                    }}, MultiShapeWithHoles{{
                         {build_rectangle(1, 11, -1, 2)},
-                    },
+                    }},
                 },
                 {
                     {build_rectangle(1, 2, 0, 1)},
@@ -470,9 +470,9 @@ INSTANTIATE_TEST_SUITE_P(
             }, {  // Three groups, each a single shape.
                 "ThreeGroupsIntersection",
                 {
-                    {{build_rectangle(0, 10, 0, 10)}},
-                    {{build_rectangle(5, 15, -5, 5)}},
-                    {{build_rectangle(-5, 8, 2, 8)}},
+                    MultiShapeWithHoles{{{build_rectangle(0, 10, 0, 10)}}},
+                    MultiShapeWithHoles{{{build_rectangle(5, 15, -5, 5)}}},
+                    MultiShapeWithHoles{{{build_rectangle(-5, 8, 2, 8)}}},
                 },
                 {
                     {build_rectangle(5, 8, 2, 5)},
@@ -481,15 +481,15 @@ INSTANTIATE_TEST_SUITE_P(
                // the intersection must be empty.
                 "EmptyGroupYieldsEmptyResult",
                 {
-                    {{build_rectangle(0, 10, 0, 10)}},
-                    {},
+                    MultiShapeWithHoles{{{build_rectangle(0, 10, 0, 10)}}},
+                    MultiShapeWithHoles{},
                 },
                 {},
             }, {  // Groups whose unions don't overlap at all.
                 "NonOverlappingGroupsYieldEmptyResult",
                 {
-                    {{build_rectangle(0, 5, 0, 5)}},
-                    {{build_rectangle(10, 15, 10, 15)}},
+                    MultiShapeWithHoles{{{build_rectangle(0, 5, 0, 5)}}},
+                    MultiShapeWithHoles{{{build_rectangle(10, 15, 10, 15)}}},
                 },
                 {},
             }, {  // One group has two pieces that overlap each other,
@@ -497,12 +497,12 @@ INSTANTIATE_TEST_SUITE_P(
                // straddling both pieces.
                 "OverlappingPiecesWithinGroup",
                 {
-                    {
+                    MultiShapeWithHoles{{
                         {build_rectangle(0, 2, 0, 2)},
                         {build_rectangle(1, 2, 0, 4)},
-                    }, {
+                    }}, MultiShapeWithHoles{{
                         {build_rectangle(0.5, 1.5, 1, 3)},
-                    },
+                    }},
                 },
                 {
                     {build_shape({
@@ -519,8 +519,8 @@ INSTANTIATE_TEST_SUITE_P(
 struct ComputeBooleanDifferenceTestParams
 {
     std::string name;
-    std::vector<ShapeWithHoles> shapes_1;
-    std::vector<ShapeWithHoles> shapes;
+    MultiShapeWithHoles shapes_1;
+    MultiShapeWithHoles shapes;
     std::vector<ShapeWithHoles> expected_output;
 
 
@@ -538,10 +538,8 @@ struct ComputeBooleanDifferenceTestParams
         file >> json;
         ComputeBooleanDifferenceTestParams test_params;
         test_params.name = file_path;
-        for (auto& json_shape: json["shapes_1"].items())
-            test_params.shapes_1.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
-        for (auto& json_shape: json["shapes"].items())
-            test_params.shapes.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
+        test_params.shapes_1 = MultiShapeWithHoles::from_json(json["shapes_1"]);
+        test_params.shapes = MultiShapeWithHoles::from_json(json["shapes"]);
         for (auto& json_shape: json["expected_output"].items())
             test_params.expected_output.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
         return test_params;
@@ -552,10 +550,10 @@ void PrintTo(const ComputeBooleanDifferenceTestParams& params, std::ostream* os)
 {
     *os << "Testing " << params.name << "...\n";
     *os << "shapes_1\n";
-    for (const ShapeWithHoles& shape: params.shapes_1)
+    for (const ShapeWithHoles& shape: params.shapes_1.shapes_with_holes)
         *os << "- " << shape.to_string(2) << "\n";
     *os << "shapes\n";
-    for (const ShapeWithHoles& shape: params.shapes)
+    for (const ShapeWithHoles& shape: params.shapes.shapes_with_holes)
         *os << "- " << shape.to_string(2) << "\n";
     *os << "expected_output\n";
     for (const ShapeWithHoles& shape: params.expected_output)
@@ -571,7 +569,7 @@ TEST_P(ComputeBooleanDifferenceTest, ComputeBooleanDifference)
 
     auto output = compute_difference(
             test_params.shapes_1,
-            test_params.shapes);
+            test_params.shapes).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << "- " << shape.to_string(2) << std::endl;
@@ -611,8 +609,8 @@ INSTANTIATE_TEST_SUITE_P(
 struct ComputeBooleanSymmetricDifferenceTestParams
 {
     std::string name;
-    std::vector<ShapeWithHoles> shapes_1;
-    std::vector<ShapeWithHoles> shapes_2;
+    MultiShapeWithHoles shapes_1;
+    MultiShapeWithHoles shapes_2;
     std::vector<ShapeWithHoles> expected_output;
 
 
@@ -630,10 +628,8 @@ struct ComputeBooleanSymmetricDifferenceTestParams
         file >> json;
         ComputeBooleanSymmetricDifferenceTestParams test_params;
         test_params.name = file_path;
-        for (auto& json_shape: json["shapes_1"].items())
-            test_params.shapes_1.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
-        for (auto& json_shape: json["shapes_2"].items())
-            test_params.shapes_2.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
+        test_params.shapes_1 = MultiShapeWithHoles::from_json(json["shapes_1"]);
+        test_params.shapes_2 = MultiShapeWithHoles::from_json(json["shapes_2"]);
         for (auto& json_shape: json["expected_output"].items())
             test_params.expected_output.emplace_back(ShapeWithHoles::from_json(json_shape.value()));
         return test_params;
@@ -644,10 +640,10 @@ void PrintTo(const ComputeBooleanSymmetricDifferenceTestParams& params, std::ost
 {
     *os << "Testing " << params.name << "...\n";
     *os << "shapes_1\n";
-    for (const ShapeWithHoles& shape: params.shapes_1)
+    for (const ShapeWithHoles& shape: params.shapes_1.shapes_with_holes)
         *os << "- " << shape.to_string(2) << "\n";
     *os << "shapes_2\n";
-    for (const ShapeWithHoles& shape: params.shapes_2)
+    for (const ShapeWithHoles& shape: params.shapes_2.shapes_with_holes)
         *os << "- " << shape.to_string(2) << "\n";
     *os << "expected_output\n";
     for (const ShapeWithHoles& shape: params.expected_output)
@@ -663,7 +659,7 @@ TEST_P(ComputeBooleanSymmetricDifferenceTest, ComputeBooleanSymetricDifference)
 
     auto output = compute_symmetric_difference(
             test_params.shapes_1,
-            test_params.shapes_2);
+            test_params.shapes_2).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << "- " << shape.to_string(2) << std::endl;
@@ -890,7 +886,7 @@ TEST_P(BridgeTouchingHolesTest, BridgeTouchingHoles)
     BridgeTouchingHolesTestParams test_params = GetParam();
     PrintTo(test_params, &std::cout);
 
-    std::vector<ShapeWithHoles> output = bridge_touching_holes(test_params.shape);
+    std::vector<ShapeWithHoles> output = bridge_touching_holes(test_params.shape).shapes_with_holes;
     std::cout << "output" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << shape.to_string(2) << std::endl;

--- a/test/clean_test.cpp
+++ b/test/clean_test.cpp
@@ -265,7 +265,7 @@ TEST_P(FixSelfIntersectionsTest, FixSelfIntersections)
 {
     FixSelfIntersectionsTestParams test_params = GetParam();
     PrintTo(test_params, &std::cout);
-    std::vector<ShapeWithHoles> output = fix_self_intersections(test_params.shape);
+    std::vector<ShapeWithHoles> output = fix_self_intersections(test_params.shape).shapes_with_holes;
     std::cout << "output:" << std::endl;
     for (const ShapeWithHoles& shape: output)
         std::cout << shape.to_string(2) << std::endl;

--- a/test/convex_partition_test.cpp
+++ b/test/convex_partition_test.cpp
@@ -57,7 +57,7 @@ TEST_P(ConvexPartitionTest, ConvexPartition)
 
     // Check 3: the union of all parts equals the input shape.
     std::vector<ShapeWithHoles> union_output =
-        compute_union(parts_as_shapes_with_holes);
+        compute_union(parts_as_shapes_with_holes).shapes_with_holes;
     std::cout << "union contains " << union_output.size() << " shape(s)" << std::endl;
     if (!union_output.empty())
         std::cout << "union: " << union_output[0].to_string(0) << std::endl;

--- a/test/no_fit_polygon_test.cpp
+++ b/test/no_fit_polygon_test.cpp
@@ -131,7 +131,7 @@ TEST_P(NoFitPolygonGeneralTest, NoFitPolygonGeneral)
 
     std::vector<ShapeWithHoles> nfp = no_fit_polygon(
             test_params.fixed_shape,
-            test_params.orbiting_shape);
+            test_params.orbiting_shape).shapes_with_holes;
 
     std::cout << "nfp (" << nfp.size() << " component(s))" << std::endl;
     for (const ShapeWithHoles& component: nfp)

--- a/test/rasterization_test.cpp
+++ b/test/rasterization_test.cpp
@@ -132,8 +132,8 @@ TEST_P(RasterizationTest, Rasterization)
     std::vector<Cell> all_cells;
     for (const IntersectedCell& cell: cells)
         all_cells.push_back(cell.cell);
-    ShapeWithHoles cells_union = cells_to_shapes(all_cells, test_params.cell_width, test_params.cell_height).front();
-    std::vector<ShapeWithHoles> union_output = compute_union({cells_union, test_params.shape});
+    ShapeWithHoles cells_union = cells_to_shapes(all_cells, test_params.cell_width, test_params.cell_height).shapes_with_holes.front();
+    std::vector<ShapeWithHoles> union_output = compute_union({cells_union, test_params.shape}).shapes_with_holes;
     EXPECT_EQ(union_output.size(), 1);
     EXPECT_TRUE(equal(union_output.front(), cells_union));
 }


### PR DESCRIPTION
Wraps std::vector<ShapeWithHoles> as a first-class type representing one coherent multi-region shape (a union of possibly-disjoint ShapeWithHoles), with shift, to_json/from_json/read_json/write_json, and to_svg methods mirroring ShapeWithHoles's own API.

Threaded through compute_difference, compute_symmetric_difference, bridge_touching_holes, fix_self_intersections, cells_to_shapes, and no_fit_polygon (general overload), plus the return type of compute_union and compute_intersection (flat overload). Their inputs stay std::vector<ShapeWithHoles> since each element there is individually significant rather than one coherent region.

Also removes the free shift(std::vector<ShapeWithHoles>&, x, y) overload, now unused and fully superseded by MultiShapeWithHoles::shift().