### PR TITLE
Add ShapeWithHoles convenience overloads for intersection/difference/symmetric_difference

### DIFF
--- a/include/shape/boolean_operations.hpp
+++ b/include/shape/boolean_operations.hpp
@@ -47,6 +47,13 @@ std::vector<ShapeWithHoles> compute_intersection_faces(
         const std::vector<MultiShapeWithHoles>& multi_shapes);
 
 /**
+ * Convenience overload of compute_intersection for two single shapes.
+ */
+MultiShapeWithHoles compute_intersection(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2);
+
+/**
  * Compute the difference between two multi-shapes.
  */
 MultiShapeWithHoles compute_difference(
@@ -54,11 +61,26 @@ MultiShapeWithHoles compute_difference(
         const MultiShapeWithHoles& shapes_2);
 
 /**
+ * Convenience overload of compute_difference for two single shapes.
+ */
+MultiShapeWithHoles compute_difference(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2);
+
+/**
  * Compute the symmetric difference between two multi-shapes.
  */
 MultiShapeWithHoles compute_symmetric_difference(
         const MultiShapeWithHoles& shapes_1,
         const MultiShapeWithHoles& shapes_2);
+
+/**
+ * Convenience overload of compute_symmetric_difference for two single
+ * shapes.
+ */
+MultiShapeWithHoles compute_symmetric_difference(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2);
 
 Shape extract_outline(
         const Shape& shape);

--- a/src/boolean_operations.cpp
+++ b/src/boolean_operations.cpp
@@ -1577,6 +1577,13 @@ MultiShapeWithHoles shape::compute_intersection(
     return compute_union(compute_intersection_faces(multi_shapes));
 }
 
+MultiShapeWithHoles shape::compute_intersection(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2)
+{
+    return compute_intersection(std::vector<ShapeWithHoles>{shape_1, shape_2});
+}
+
 MultiShapeWithHoles shape::compute_difference(
         const MultiShapeWithHoles& shapes_1,
         const MultiShapeWithHoles& shapes_2)
@@ -1590,6 +1597,15 @@ MultiShapeWithHoles shape::compute_difference(
     return compute_union(faces);
 }
 
+MultiShapeWithHoles shape::compute_difference(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2)
+{
+    return compute_difference(
+            MultiShapeWithHoles{{shape_1}},
+            MultiShapeWithHoles{{shape_2}});
+}
+
 MultiShapeWithHoles shape::compute_symmetric_difference(
         const MultiShapeWithHoles& shapes_1,
         const MultiShapeWithHoles& shapes_2)
@@ -1601,6 +1617,15 @@ MultiShapeWithHoles shape::compute_symmetric_difference(
             BooleanOperation::SymmetricDifference,
             shapes_1.shapes_with_holes.size());
     return compute_union(faces);
+}
+
+MultiShapeWithHoles shape::compute_symmetric_difference(
+        const ShapeWithHoles& shape_1,
+        const ShapeWithHoles& shape_2)
+{
+    return compute_symmetric_difference(
+            MultiShapeWithHoles{{shape_1}},
+            MultiShapeWithHoles{{shape_2}});
 }
 
 Shape shape::extract_outline(


### PR DESCRIPTION
compute_difference and compute_symmetric_difference take two MultiShapeWithHoles operands, and compute_intersection's grouped overload takes a vector of MultiShapeWithHoles -- all of which require wrapping a lone ShapeWithHoles into a singleton MultiShapeWithHoles for the common case of combining just two plain shapes. Add two-argument ShapeWithHoles/ShapeWithHoles overloads for all three that do that wrapping internally.

compute_intersection(const std::vector<ShapeWithHoles>&) already covered the vector-input case (N-ary AND across individually-significant shapes), so no new overload was needed there.