### PR TITLE
Make ShapeElement::contains() a parametric projection check

### DIFF
--- a/include/shape/shape.hpp
+++ b/include/shape/shape.hpp
@@ -184,22 +184,34 @@ LengthDbl squared_distance(
         const Point& point_1,
         const Point& point_2);
 
+/**
+ * Ratio t such that line_point_1 + t * (line_point_2 - line_point_1) is the
+ * projection of 'point' onto the (infinite) line through line_point_1 and
+ * line_point_2. t is unclamped: 0 at line_point_1, 1 at line_point_2, and
+ * outside [0, 1] if the projection falls beyond either point.
+ */
+inline LengthDbl project_point_on_line_ratio(
+        const Point& line_point_1,
+        const Point& line_point_2,
+        const Point& point)
+{
+    LengthDbl bx = line_point_2.x - line_point_1.x;
+    LengthDbl by = line_point_2.y - line_point_1.y;
+    LengthDbl px = point.x - line_point_1.x;
+    LengthDbl py = point.y - line_point_1.y;
+    LengthDbl denom = std::fma(bx, bx, by * by);
+    return std::fma(px, bx, py * by) / denom;
+}
+
 inline Point project_point_on_line(
         const Point& line_point_1,
         const Point& line_point_2,
         const Point& point)
 {
-    LengthDbl ax = line_point_1.x;
-    LengthDbl ay = line_point_1.y;
-    LengthDbl bx = line_point_2.x - ax;
-    LengthDbl by = line_point_2.y - ay;
-    LengthDbl px = point.x - ax;
-    LengthDbl py = point.y - ay;
-    LengthDbl denom = std::fma(bx, bx, by * by);
-    LengthDbl t = std::fma(px, bx, py * by) / denom;
+    LengthDbl t = project_point_on_line_ratio(line_point_1, line_point_2, point);
     Point q;
-    q.x = ax + t * bx;
-    q.y = ay + t * by;
+    q.x = line_point_1.x + t * (line_point_2.x - line_point_1.x);
+    q.y = line_point_1.y + t * (line_point_2.y - line_point_1.y);
     return q;
 }
 
@@ -382,8 +394,6 @@ struct ShapeElement
 
     /** If the element is a CircularArc, direction of the rotation. */
     ShapeElementOrientation orientation = ShapeElementOrientation::Anticlockwise;
-
-    bool in_circular_arc_cone(const Point& point) const;
 
     /** Check if a point is on the element. */
     bool contains(const Point& point) const;

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -3,6 +3,7 @@
 #include "shape/elements_intersections.hpp"
 #include "shape/shapes_intersections.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -506,61 +507,45 @@ bool shape::strictly_greater_angle(
 ///////////////////////////////// ShapeElement /////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-bool ShapeElement::in_circular_arc_cone(const Point& point) const
-{
-    LengthDbl radius = distance(center, start);
-    if (this->orientation == ShapeElementOrientation::Full) {
-        return true;
-    } else if (this->orientation == ShapeElementOrientation::Anticlockwise) {
-        LengthDbl a0 = radius * angle_radian(
-                this->start - this->center,
-                this->end - this->center);
-        LengthDbl a = radius * angle_radian(
-                this->start - this->center,
-                point - this->center);
-        return !strictly_greater(a, a0);
-    } else {
-        LengthDbl a0 = radius * angle_radian(
-                this->end - this->center,
-                this->start - this->center);
-        LengthDbl a = radius * angle_radian(
-                this->end - this->center,
-                point - this->center);
-        return !strictly_greater(a, a0);
-    }
-    return false;
-}
-
 bool ShapeElement::contains(const Point& point) const
 {
-    // A point matching an endpoint is trivially contained, regardless of
-    // element type, even if it narrowly fails the stricter checks below: for
-    // a LineSegment, near an endpoint, the betweenness check's distance-sum
-    // excess grows about twice as fast as the endpoint distance itself, so it
-    // can exceed the tolerance while the point is still `equal` to the
-    // endpoint; for a CircularArc, the stored endpoint isn't always perfectly
-    // consistent with its own center and radius, so the same kind of gap can
-    // arise in the on-circle / angular-cone checks.
-    if (equal(point, this->start) || equal(point, this->end))
-        return true;
+    // An element must contain any point 'equal' (within tolerance) to
+    // this->point(l) for some l in [0, this->length()]. To check this
+    // robustly, find the closest point of the element to 'point' (clamped to
+    // the element's valid range) and check that it really is (within
+    // tolerance) the given point, rather than checking element-type-specific
+    // geometric properties (on-line, on-circle, angular cone, ...) whose
+    // tolerance behavior is inconsistent close to the element's endpoints.
+    LengthDbl l;
     switch (type) {
     case ShapeElementType::LineSegment: {
-        if (!line_contains(this->start, this->end, point))
-            return false;
-        return !strictly_greater(
-                distance(this->start, point) + distance(point, this->end),
-                distance(this->start, this->end));
-    } case ShapeElementType::CircularArc: {
-        // Check if point lies on circle
-        if (!equal(
-                    distance(point, this->center),
-                    distance(this->start, this->center))) {
-            return false;
+        if (this->start == this->end) {
+            l = 0.0;
+            break;
         }
-        return this->in_circular_arc_cone(point);
+        // Project along the segment's own direction (the same fma-based
+        // computation as project_point_on_line): this isolates the
+        // along-segment component of 'point' from any perpendicular
+        // deviation, unlike using distance(start, point) (an unsigned,
+        // direction-agnostic estimate) as a stand-in for the parameter,
+        // which would conflate the two and could push the estimate off by
+        // as much as the perpendicular deviation itself.
+        LengthDbl t = project_point_on_line_ratio(this->start, this->end, point);
+        l = t * this->length();
+        break;
+    } case ShapeElementType::CircularArc: {
+        // this->length(point) only depends on the direction of
+        // (point - center) (via an angle), not on its magnitude, so unlike
+        // the LineSegment case, it is already unaffected by any radial
+        // deviation of 'point' from the circle.
+        l = this->length(point);
+        break;
+    } default: {
+        return false;
     }
     }
-    return false;
+    l = (std::max)(0.0, (std::min)(this->length(), l));
+    return equal(point, this->point(l));
 }
 
 LengthDbl ShapeElement::length() const

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -465,6 +465,26 @@ INSTANTIATE_TEST_SUITE_P(
                 {7.0710687118654755, 7.0710687118654755},
                 true,
             },
+            // General guarantee: a point equal (within tolerance) to
+            // element.point(l) for some interior l (not an endpoint) must be
+            // contained.
+            {
+                build_line_segment({0, 0}, {10, 0}),
+                {5.0000009, 0.0000009},
+                true,
+            },
+            {
+                build_circular_arc({10, 0}, {0, 10}, {0, 0}, ShapeElementOrientation::Anticlockwise),
+                {9.238796225112868, 3.826833423650898},
+                true,
+            },
+            // Negative control: same arc, but off the circle (radius off by
+            // ~1e-3) by far more than tolerance.
+            {
+                build_circular_arc({10, 0}, {0, 10}, {0, 0}, ShapeElementOrientation::Anticlockwise),
+                {9.239719204645379, 3.827217007083263},
+                false,
+            },
         }),
         [](const testing::TestParamInfo<ShapeElementContainsTest::ParamType>& info) {
             return std::to_string(info.index);


### PR DESCRIPTION
The previous fix (already on main) special-cased the two endpoints: a point equal (within tolerance) to start or end is now trivially contained, since the per-type geometric checks (on-line betweenness, on-circle + angular cone) could reject them despite the tolerance. But the actual guarantee needed is broader: an element must contain any point equal to this->point(l) for any l in [0, this->length()], not just l = 0 or l = length().

Rework contains() to check this directly and uniformly for both element types: compute the length l that best explains 'point' (via a proper projection for LineSegment, via the existing direction-only this->length(point) for CircularArc), clamp it to the valid range, and check that this->point(l) really is (within tolerance) the given point. This sidesteps the inconsistent tolerance behavior of the old per-type checks entirely, rather than special-casing endpoints.

For LineSegment, the projection must isolate the along-segment component from any perpendicular deviation of 'point' (a raw distance(start, point) estimate, as used in an earlier iteration of this fix, conflates the two and can push the estimate off by as much as the perpendicular deviation itself). Extract the existing fma-based projection ratio out of project_point_on_line into project_point_on_line_ratio so both it and contains() share the same numerically careful computation instead of independently reimplementing it.

in_circular_arc_cone is no longer used anywhere (it was only ever called from the old contains()) and is removed; it was not itself the source of the CircularArc bug (that was the separate on-circle radius check, which no longer exists either).