### PR TITLE
Support circular arcs in no_fit_polygon

### DIFF
--- a/include/shape/basic_shapes.hpp
+++ b/include/shape/basic_shapes.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "shape/shape.hpp"
+
+#include <vector>
+
+namespace shape
+{
+
+enum class BasicShapeType
+{
+    ConvexPolygon,
+    CircularSegment,
+};
+
+/**
+ * A basic shape:
+ * - ConvexPolygon: shape is the polygon K
+ * - CircularSegment: shape is the segment itself, closed by the arc and its
+ *   chord (one CircularArc element followed by one LineSegment element back
+ *   to the arc's start); circle_center and circle_radius redundantly give
+ *   the arc's circle.
+ */
+struct BasicShape
+{
+    BasicShapeType type = BasicShapeType::ConvexPolygon;
+    Shape shape;
+    Point circle_center = {0, 0};
+    LengthDbl circle_radius = 0;
+};
+
+struct BasicShapesDecomposition
+{
+    std::vector<BasicShape> basic_shapes;
+};
+
+/**
+ * Decompose a shape (with holes) whose boundary consists of line segments and
+ * convex circular arcs into basic objects: convex polygons and circular
+ * segments.
+ *
+ * Each convex-from-the-material arc is cut off as a circular segment (arc +
+ * chord), leaving a pure polygon (with holes) which is then split into convex
+ * parts. If a chord would cross another boundary element of the same loop,
+ * the arc is subdivided at its midpoint and the halves are retried.
+ *
+ * Holes are stored in the same anticlockwise direction as the outer boundary
+ * (see Shape's own doc comment), so the arc orientation that is "convex from
+ * the material's side" is Anticlockwise for the outer boundary but Clockwise
+ * for a hole: a Clockwise arc in a hole is material bulging into the void,
+ * the hole equivalent of a convex bump.
+ */
+BasicShapesDecomposition decompose_into_basic_shapes(const ShapeWithHoles& shape);
+
+/** Convenience overload for a shape with no holes. */
+inline BasicShapesDecomposition decompose_into_basic_shapes(const Shape& shape)
+{
+    ShapeWithHoles shape_with_holes;
+    shape_with_holes.shape = shape;
+    return decompose_into_basic_shapes(shape_with_holes);
+}
+
+}

--- a/include/shape/no_fit_polygon.hpp
+++ b/include/shape/no_fit_polygon.hpp
@@ -15,13 +15,21 @@ namespace shape
  * A point p lies inside the NFP iff placing B's origin at p causes B and A
  * to overlap. A point on the boundary means they just touch.
  *
- * Both shapes must be convex polygons (only line-segment elements, CCW
- * winding). An exception is thrown otherwise.
+ * Both shapes must be convex (CCW winding); an exception is thrown
+ * otherwise. Elements may be a mix of LineSegment and CircularArc, with any
+ * number of arcs, as long as each individual arc spans < 180° (an exception
+ * is thrown otherwise) -- e.g. the result of inflating a convex polygon,
+ * which rounds every corner into its own arc, always satisfies this, since
+ * a single polygon vertex's exterior turning angle can never reach a half
+ * turn.
  *
  * The returned shape is CCW and free of collinear (aligned) vertices.
  *
- * Algorithm: rotating-calipers Minkowski sum on convex polygons.
- * Complexity: O(m + n) where m, n are the vertex counts of A and B.
+ * Algorithm: rotating-calipers Minkowski sum, generalized from convex
+ * polygons to convex shapes with (multiple, < 180°) circular arcs by
+ * treating an arc as a continuous range of tangent directions instead of a
+ * single one, splitting/summing as needed against the other shape.
+ * Complexity: O(m + n) where m, n are the element counts of A and B.
  */
 Shape no_fit_polygon(
         const Shape& fixed_shape,
@@ -31,9 +39,9 @@ Shape no_fit_polygon(
  * Compute the No-Fit Polygon (NFP) of two general (possibly non-convex)
  * shapes.
  *
- * The algorithm decomposes each shape into convex parts via
- * compute_convex_partition, computes the convex NFP for every pair of parts,
- * then returns the union of all those convex NFPs.
+ * The algorithm decomposes each shape into convex polygons and circular
+ * segments via decompose_into_basic_shapes, computes the convex NFP for
+ * every pair of parts, then returns the union of all those convex NFPs.
  *
  * The result may consist of several disconnected components or contain holes,
  * hence the return type is a MultiShapeWithHoles.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(Shape_shape PRIVATE
     boolean_operations.cpp
     convex_hull.cpp
     convex_partition.cpp
+    basic_shapes.cpp
     clean.cpp
     extract_borders.cpp
     trapezoidation.cpp

--- a/src/basic_shapes.cpp
+++ b/src/basic_shapes.cpp
@@ -1,0 +1,193 @@
+#include "shape/basic_shapes.hpp"
+
+#include "shape/convex_partition.hpp"
+#include "shape/elements_intersections.hpp"
+
+using namespace shape;
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+LengthDbl arc_radius(const ShapeElement& arc)
+{
+    return distance(arc.start, arc.center);
+}
+
+std::pair<ShapeElement, ShapeElement> split_arc_at_midpoint(const ShapeElement& arc)
+{
+    Point midpoint = arc.middle();
+    ShapeElement first_half = build_circular_arc(arc.start, midpoint, arc.center, arc.orientation);
+    ShapeElement second_half = build_circular_arc(midpoint, arc.end, arc.center, arc.orientation);
+    return std::make_pair(first_half, second_half);
+}
+
+/**
+ * Return true if 'chord' meets 'element' anywhere other than at chord's own
+ * start or end point. Every intersection category is considered (a proper
+ * crossing, an overlapping collinear part, or an improper intersection such
+ * as a tangential touch or a shared endpoint of 'element'): the only
+ * tolerated contact is at the chord's own endpoints, where it is expected to
+ * meet its neighbouring elements.
+ */
+bool chord_intersects_element(
+        const ShapeElement& chord,
+        const ShapeElement& element)
+{
+    ShapeElementIntersectionsOutput result = compute_intersections(chord, element);
+    if (!result.overlapping_parts.empty())
+        return true;
+    for (const Point& point: result.proper_intersections)
+        if (!equal(point, chord.start) && !equal(point, chord.end))
+            return true;
+    for (const Point& point: result.improper_intersections)
+        if (!equal(point, chord.start) && !equal(point, chord.end))
+            return true;
+    return false;
+}
+
+/**
+ * Return the loop at loop_idx: index i in [0, shape.holes.size()) is
+ * shape.holes[i]; the outer boundary is returned for either out-of-range
+ * sentinel, -1 or shape.holes.size() (one step before the first hole or one
+ * step past the last), so it is reachable the same way from either end.
+ */
+Shape& loop_shape(ShapeWithHoles& shape, Counter loop_idx)
+{
+    if (loop_idx == -1 || loop_idx == (Counter)shape.holes.size())
+        return shape.shape;
+    return shape.holes[loop_idx];
+}
+
+/**
+ * Return true if the chord p1-p2 meets any element of 'shape' (the outer
+ * boundary or any hole). No exclusions are needed for the arc being cut or
+ * its two neighbours: they only ever meet the chord exactly at p1 or p2,
+ * which chord_intersects_element already tolerates.
+ */
+bool chord_intersects_boundary(
+        const ShapeWithHoles& shape,
+        const Point& p1,
+        const Point& p2)
+{
+    ShapeElement chord = build_line_segment(p1, p2);
+
+    for (const ShapeElement& element: shape.shape.elements)
+        if (chord_intersects_element(chord, element))
+            return true;
+    for (const Shape& hole: shape.holes)
+        for (const ShapeElement& element: hole.elements)
+            if (chord_intersects_element(chord, element))
+                return true;
+
+    return false;
+}
+
+/**
+ * Find and cut off convex-from-the-material circular segments from a single
+ * loop of 'shape' (loop_idx: -1 for the outer boundary, in [0,
+ * shape.holes.size()) for a hole), appending each one to 'segments'.
+ * 'convex_orientation' is the arc orientation that counts as convex from the
+ * material's side for this loop (Anticlockwise for the outer boundary,
+ * Clockwise for a hole). Mutates the loop's elements in place, replacing
+ * each cut arc by its chord.
+ */
+void cut_circular_segments(
+        ShapeWithHoles& shape,
+        Counter loop_idx,
+        ShapeElementOrientation convex_orientation,
+        std::vector<BasicShape>& segments)
+{
+    std::vector<ShapeElement>& current_elements = loop_shape(shape, loop_idx).elements;
+
+    bool found_arc = true;
+    while (found_arc) {
+        found_arc = false;
+        for (Counter element_idx = 0;
+                element_idx < (Counter)current_elements.size();
+                ++element_idx) {
+            const ShapeElement& element = current_elements[element_idx];
+            if (element.type != ShapeElementType::CircularArc)
+                continue;
+            if (element.orientation != convex_orientation)
+                continue;
+
+            found_arc = true;
+
+            // Check whether the arc subtends >= 180°; if so the tangent lines
+            // at the endpoints are parallel and no finite apex exists.
+            LengthDbl radius = arc_radius(element);
+            LengthDbl arc_angle = element.length() / radius;
+
+            bool needs_subdivision = (arc_angle >= M_PI - 1e-6)
+                    || chord_intersects_boundary(shape, element.start, element.end);
+
+            if (needs_subdivision) {
+                std::pair<ShapeElement, ShapeElement> halves =
+                        split_arc_at_midpoint(element);
+                current_elements.erase(current_elements.begin() + element_idx);
+                current_elements.insert(current_elements.begin() + element_idx, halves.second);
+                current_elements.insert(current_elements.begin() + element_idx, halves.first);
+                break;
+            }
+
+            // Cut the circular segment: its own shape is the arc closed by
+            // the chord back to its start, and the arc is replaced by that
+            // same chord in the remaining boundary.
+            //
+            // A Shape must itself be provided anticlockwise: for the outer
+            // boundary the arc is already Anticlockwise, so close it as-is;
+            // for a hole the cut-off arc is Clockwise (convex-from-material
+            // there), so the whole 2-element loop must be reversed to be a
+            // valid standalone anticlockwise shape.
+            BasicShape segment_basic_shape;
+            segment_basic_shape.type = BasicShapeType::CircularSegment;
+            segment_basic_shape.circle_center = element.center;
+            segment_basic_shape.circle_radius = radius;
+            if (convex_orientation == ShapeElementOrientation::Anticlockwise) {
+                segment_basic_shape.shape.elements = {
+                    element,
+                    build_line_segment(element.end, element.start)};
+            } else {
+                segment_basic_shape.shape.elements = {
+                    element.reverse(),
+                    build_line_segment(element.start, element.end)};
+            }
+            segments.push_back(segment_basic_shape);
+
+            current_elements[element_idx] = build_line_segment(element.start, element.end);
+            break;
+        }
+    }
+}
+
+}  // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+BasicShapesDecomposition shape::decompose_into_basic_shapes(
+        const ShapeWithHoles& shape)
+{
+    BasicShapesDecomposition output;
+
+    ShapeWithHoles remaining = shape;
+
+    cut_circular_segments(remaining, -1, ShapeElementOrientation::Anticlockwise, output.basic_shapes);
+    for (Counter loop_idx = 0; loop_idx < (Counter)remaining.holes.size(); ++loop_idx) {
+        cut_circular_segments(
+                remaining, loop_idx,
+                ShapeElementOrientation::Clockwise,
+                output.basic_shapes);
+    }
+
+    // Decompose the remaining pure polygon (with holes) into convex parts.
+    for (const Shape& convex_part: compute_convex_partition(remaining)) {
+        BasicShape polygon_basic_shape;
+        polygon_basic_shape.type = BasicShapeType::ConvexPolygon;
+        polygon_basic_shape.shape = convex_part;
+        output.basic_shapes.push_back(polygon_basic_shape);
+    }
+
+    return output;
+}

--- a/src/no_fit_polygon.cpp
+++ b/src/no_fit_polygon.cpp
@@ -5,11 +5,38 @@
 #include "shape/basic_shapes.hpp"
 
 #include <algorithm>
+#include <string>
 
 using namespace shape;
 
 namespace
 {
+
+/**
+ * Same total order as shape::strictly_lesser_angle, but tolerant of the tiny
+ * floating-point noise (on the order of 1e-16) that sqrt/trig-derived
+ * CircularArc tangent directions carry relative to tangents computed
+ * directly from stored points (e.g. a plain edge's direction, or another
+ * arc's tangent obtained through a different center/radius). By
+ * construction, an edge's direction is exactly equal to the tangent of the
+ * arc it leads into (both are the external tangent to that arc's circle),
+ * so the two *should* compare equal -- but shape::strictly_lesser_angle's
+ * own cross-product test has no tolerance at all (a bare "> 0"), so any
+ * nonzero noise gets treated as a strict order instead of a tie. For plain
+ * polygons this never bites (both directions are typically bit-identical,
+ * being derived from the same stored points via the same arithmetic), but
+ * once arcs are involved -- especially for a self-NFP, or any pair of
+ * shapes sharing rounded-corner structure -- such near-ties are frequent,
+ * and silently corrupt the tie-handling logic below every time one occurs.
+ */
+bool direction_strictly_lesser(
+        const Point& direction_1,
+        const Point& direction_2)
+{
+    if (equal(direction_1.x, direction_2.x) && equal(direction_1.y, direction_2.y))
+        return false;
+    return strictly_lesser_angle(direction_1, direction_2);
+}
 
 /**
  * Point on a circle (given center, radius, orientation) whose tangent
@@ -46,12 +73,12 @@ Point point_at_tangent_direction(
  * True if 'direction' lies strictly between arc's start and end tangent
  * directions (i.e. strictly inside the open span, not at either endpoint).
  *
- * Since every arc handled here comes from decompose_into_basic_shapes'
- * CircularSegment (span < 180°), a direction is strictly inside iff turning
- * CCW from the start tangent to 'direction' is a positive turn, and turning
- * CCW from 'direction' to the end tangent is also a positive turn -- two
- * plain cross-product sign tests, no wraparound handling needed precisely
- * because the span cannot reach 180°.
+ * no_fit_polygon requires every arc to span < 180° (see its precondition
+ * check), so a direction is strictly inside iff turning CCW from the start
+ * tangent to 'direction' is a positive turn, and turning CCW from
+ * 'direction' to the end tangent is also a positive turn -- two plain
+ * cross-product sign tests, no wraparound handling needed precisely because
+ * the span cannot reach 180°.
  */
 bool direction_strictly_inside_arc(
         const ShapeElement& arc,
@@ -109,26 +136,29 @@ std::vector<ShapeElement> split_arc_into_pieces(
 
 /**
  * Build the final ordered element list for one side of the merge (fixed or
- * orbiting): identical to 'elements' unless it contains a CircularArc, in
- * which case that arc is replaced in place by pieces pre-split at every
- * critical direction contributed by the *other* side -- each of its plain
- * edges' own tangent direction, plus (if it has one) its own arc's start and
- * end tangents.
+ * orbiting): identical to 'elements' except that every CircularArc element
+ * is replaced in place by pieces pre-split at every critical direction
+ * contributed by the *other* side -- each of its plain edges' own tangent
+ * direction, plus (for each arc it has) that arc's start and end tangents.
+ * A shape may contain any number of arcs (each still required to span
+ * < 180°); each one is split independently against the same set of
+ * other-side critical directions.
  *
  * This has to happen up front, before the main merge loop runs, rather than
  * relying purely on reactively splitting an arc against whichever direction
  * the loop happens to be comparing it to at the time: the loop only ever
- * looks at each side's *current* element, so if the arc is not the first
- * element of its shape (e.g. decompose_into_basic_shapes' circular segment
- * starts with its chord instead, depending on which point ends up
- * bottom/top-most), some of the other side's edges can be fully consumed
- * against something else entirely before the arc ever becomes current --
- * permanently missing a split their direction should have triggered.
+ * looks at each side's *current* element, so if an arc is not the first
+ * element of its shape (e.g. a circular segment cut off by
+ * decompose_into_basic_shapes starts with its chord instead, depending on
+ * which point ends up bottom/top-most), some of the other side's edges can
+ * be fully consumed against something else entirely before that arc ever
+ * becomes current -- permanently missing a split their direction should
+ * have triggered.
  *
  * 'negate_self'/'negate_other' select which of 'elements'/'other_elements'
  * is the orbiting side, whose directions get negated for output space (see
- * EdgeCursor below); both direction sets need to end up expressed in the
- * *arc's own local frame* to be tested/split against it.
+ * EdgeCursor below); both direction sets need to end up expressed in each
+ * arc's own local frame to be tested/split against it.
  */
 std::vector<ShapeElement> presplit_elements(
         const std::vector<ShapeElement>& elements,
@@ -136,16 +166,20 @@ std::vector<ShapeElement> presplit_elements(
         const std::vector<ShapeElement>& other_elements,
         bool negate_other)
 {
-    ElementPos arc_pos = -1;
-    for (ElementPos i = 0; i < (ElementPos)elements.size(); ++i) {
-        if (elements[i].type == ShapeElementType::CircularArc) {
-            arc_pos = i;
+    bool has_arc = false;
+    for (const ShapeElement& element: elements) {
+        if (element.type == ShapeElementType::CircularArc) {
+            has_arc = true;
             break;
         }
     }
-    if (arc_pos == -1)
+    if (!has_arc)
         return elements;
 
+    // Critical directions depend only on other_elements (and the negation
+    // flags), never on which or how many arcs 'elements' itself has, so
+    // they only need computing once and are then reused for every arc
+    // found below.
     std::vector<Point> critical_directions;
     for (const ShapeElement& other: other_elements) {
         Point d_start = other.tangent(other.start);
@@ -166,7 +200,7 @@ std::vector<ShapeElement> presplit_elements(
 
     // Also always split at the global tangent-order minimum direction (1,0)
     // [negated to (-1,0) in local frame if this is the orbiting side]: if
-    // the arc's span straddles it, the piece starting exactly there needs
+    // an arc's span straddles it, the piece starting exactly there needs
     // to exist so the start-position selection below can find it. Without
     // this, an arc whose span straddles that direction can undercut every
     // other candidate's own start direction (its tangent dips below all of
@@ -174,17 +208,15 @@ std::vector<ShapeElement> presplit_elements(
     // any element actually starting there for the selection to pick.
     critical_directions.push_back(negate_self? Point{-1.0, 0.0}: Point{1.0, 0.0});
 
-    std::vector<ShapeElement> pieces = split_arc_into_pieces(elements[arc_pos], critical_directions);
-
     std::vector<ShapeElement> result;
-    result.reserve(elements.size() - 1 + pieces.size());
-    for (ElementPos i = 0; i < (ElementPos)elements.size(); ++i) {
-        if (i != arc_pos) {
-            result.push_back(elements[i]);
-        } else {
-            for (const ShapeElement& piece: pieces)
-                result.push_back(piece);
+    result.reserve(elements.size());
+    for (const ShapeElement& element: elements) {
+        if (element.type != ShapeElementType::CircularArc) {
+            result.push_back(element);
+            continue;
         }
+        for (const ShapeElement& piece: split_arc_into_pieces(element, critical_directions))
+            result.push_back(piece);
     }
     return result;
 }
@@ -336,14 +368,16 @@ void consume_up_to(
 
 /**
  * Handle the case where both cursors currently point at a CircularArc
- * element (only possible when both input shapes are CircularSegment basic
- * shapes). If their tangent-direction spans don't overlap, the earlier one
- * is consumed alone as usual. If they do overlap, the two circles are summed
- * over the overlapping direction range -- for two circular arcs sharing a
- * range of tangent (equivalently: normal) directions, their Minkowski sum
- * over that range is itself a circular arc: center = sum of centers, radius
- * = sum of radii, same direction range. Any non-overlapping prefix/suffix on
- * either side is emitted separately as a lone arc contribution.
+ * element (possible whenever both shapes have at least one arc; with
+ * several arcs per shape this can trigger more than once over the course of
+ * the merge, once per pair of arcs that end up concurrently current). If
+ * their tangent-direction spans don't overlap, the earlier one is consumed
+ * alone as usual. If they do overlap, the two circles are summed over the
+ * overlapping direction range -- for two circular arcs sharing a range of
+ * tangent (equivalently: normal) directions, their Minkowski sum over that
+ * range is itself a circular arc: center = sum of centers, radius = sum of
+ * radii, same direction range. Any non-overlapping prefix/suffix on either
+ * side is emitted separately as a lone arc contribution.
  */
 void handle_arc_arc(
         EdgeCursor& fixed,
@@ -357,8 +391,8 @@ void handle_arc_arc(
     Point o_end = orbiting.end_direction();
 
     // f_span/o_span: each side's own tangent span, in (0, pi) -- guaranteed
-    // small since decompose_into_basic_shapes never produces an arc spanning
-    // >= 180 degrees, and that guarantee survives negation (a uniform shift
+    // small by no_fit_polygon's precondition that no arc spans >= 180
+    // degrees, and that guarantee survives negation (a uniform shift
     // changes where the pair sits, not their relative separation).
     //
     // strictly_lesser_angle (used elsewhere in this file) is NOT safe here:
@@ -458,32 +492,36 @@ Shape shape::no_fit_polygon(
                 FUNC_SIGNATURE + "; "
                 "orbiting_shape is not convex.");
     }
-    // The algorithm below merges each shape's own element sequence with the
-    // other's, splitting an arc reactively whenever the other side's current
-    // direction falls inside it; with more than one arc per shape the
-    // "at most one arc in progress per side" assumption breaks down.
-    // decompose_into_basic_shapes' CircularSegment (the intended source of
-    // arc-containing input here) always has exactly one.
-    auto count_arcs = [](const Shape& s) {
-        ElementPos n = 0;
-        for (const ShapeElement& e: s.elements)
-            if (e.type == ShapeElementType::CircularArc)
-                ++n;
-        return n;
+    // Every arc must span < 180°: direction_strictly_inside_arc's
+    // two-cross-product membership test and handle_arc_arc's overlap
+    // detection both rely on an arc's own start and end tangent directions
+    // determining a unique "short way" between them, which stops being true
+    // at or past a half turn (see direction_strictly_inside_arc's and
+    // handle_arc_arc's comments). There is no limit on how many such arcs a
+    // shape may contain -- e.g. every corner of an inflated convex polygon
+    // rounds into its own arc, and all of those are individually well under
+    // 180° since a single polygon vertex's exterior turning angle can never
+    // reach a half turn.
+    auto check_arc_spans = [](const Shape& s, const char* shape_name) {
+        for (const ShapeElement& element: s.elements) {
+            if (element.type != ShapeElementType::CircularArc)
+                continue;
+            Angle span = angle_radian(
+                    element.tangent(element.start),
+                    element.tangent(element.end));
+            if (!strictly_lesser(span, M_PI)) {
+                throw std::runtime_error(
+                        FUNC_SIGNATURE + "; "
+                        + std::string(shape_name) + " has a circular arc "
+                        "spanning >= 180 degrees.");
+            }
+        }
     };
-    if (count_arcs(fixed_shape) > 1) {
-        throw std::runtime_error(
-                FUNC_SIGNATURE + "; "
-                "fixed_shape has more than one circular arc.");
-    }
-    if (count_arcs(orbiting_shape) > 1) {
-        throw std::runtime_error(
-                FUNC_SIGNATURE + "; "
-                "orbiting_shape has more than one circular arc.");
-    }
+    check_arc_spans(fixed_shape, "fixed_shape");
+    check_arc_spans(orbiting_shape, "orbiting_shape");
 
-    // Pre-split each side's arc (if any), in its original (unrotated) index
-    // order, against the other side's critical directions -- see
+    // Pre-split each side's arcs (if any), in their original (unrotated)
+    // index order, against the other side's critical directions -- see
     // presplit_elements' comment for why this can't be done reactively
     // during the merge below, and for why it also always splits at the
     // global tangent-order minimum direction. Both calls read from the
@@ -511,7 +549,7 @@ Shape shape::no_fit_polygon(
     // continuously across its span and could dip below every other
     // element's own start direction partway through without any element
     // actually starting there -- which is exactly why presplit_elements
-    // above always splits an arc at the global minimum direction (1, 0)
+    // above always splits every arc at the global minimum direction (1, 0)
     // too, guaranteeing there is always an element that starts exactly
     // there for this search to find.
     ElementPos fixed_start_pos = 0;
@@ -520,7 +558,7 @@ Shape shape::no_fit_polygon(
             ++fixed_pos) {
         const ShapeElement& element = fixed_elements[fixed_pos];
         const ShapeElement& best = fixed_elements[fixed_start_pos];
-        if (strictly_lesser_angle(
+        if (direction_strictly_lesser(
                 element.tangent(element.start),
                 best.tangent(best.start))) {
             fixed_start_pos = fixed_pos;
@@ -535,7 +573,7 @@ Shape shape::no_fit_polygon(
         const ShapeElement& best = orbiting_elements[orbiting_start_pos];
         Point element_dir = element.tangent(element.start);
         Point best_dir = best.tangent(best.start);
-        if (strictly_lesser_angle(
+        if (direction_strictly_lesser(
                 Point{-element_dir.x, -element_dir.y},
                 Point{-best_dir.x, -best_dir.y})) {
             orbiting_start_pos = orbiting_pos;
@@ -579,8 +617,8 @@ Shape shape::no_fit_polygon(
     // one; whenever the other side's current direction falls strictly
     // inside that range, the arc is split there so only the relevant prefix
     // is merged in, leaving the remainder for later iterations. Two arcs
-    // active on both sides at once (only possible when both original shapes
-    // are circular segments) are summed over their overlapping range -- see
+    // active on both sides at once (possible whenever both shapes have at
+    // least one arc) are summed over their overlapping range -- see
     // handle_arc_arc.
     //
     // When two edges have the same direction (parallel) they are both added
@@ -611,9 +649,9 @@ Shape shape::no_fit_polygon(
         Point fixed_dir = fixed_cursor.start_direction();
         Point orbiting_dir = orbiting_cursor.start_direction();
 
-        if (strictly_lesser_angle(fixed_dir, orbiting_dir)) {
+        if (direction_strictly_lesser(fixed_dir, orbiting_dir)) {
             consume_up_to(fixed_cursor, orbiting_dir, result, current_vertex);
-        } else if (strictly_lesser_angle(orbiting_dir, fixed_dir)) {
+        } else if (direction_strictly_lesser(orbiting_dir, fixed_dir)) {
             consume_up_to(orbiting_cursor, fixed_dir, result, current_vertex);
         } else if (!fixed_is_arc && !orbiting_is_arc) {
             // Tied plain edges: fixed first, then orbiting (matches the

--- a/src/no_fit_polygon.cpp
+++ b/src/no_fit_polygon.cpp
@@ -2,24 +2,452 @@
 
 #include "shape/boolean_operations.hpp"
 #include "shape/clean.hpp"
-#include "shape/convex_partition.hpp"
+#include "shape/basic_shapes.hpp"
+
+#include <algorithm>
 
 using namespace shape;
+
+namespace
+{
+
+/**
+ * Point on a circle (given center, radius, orientation) whose tangent
+ * direction (for a CCW/Anticlockwise traversal) is parallel to
+ * 'target_direction'. Used both to split an existing arc element at a given
+ * direction, and to place the endpoint of a newly-constructed (summed) arc.
+ *
+ * Derived by inverting ShapeElement::tangent(): for an Anticlockwise arc,
+ * tangent(p) = normalize((p - center).rotate(90)), so the radial direction
+ * (p - center) is target_direction.rotate(-90); for Clockwise it is
+ * target_direction.rotate(90).
+ */
+Point point_at_tangent_direction(
+        const Point& center,
+        LengthDbl radius,
+        ShapeElementOrientation orientation,
+        const Point& target_direction)
+{
+    Point radial_direction = (orientation != ShapeElementOrientation::Clockwise)?
+        target_direction.rotate(-90.0):
+        target_direction.rotate(90.0);
+    return center + radius * normalize(radial_direction);
+}
+
+Point point_at_tangent_direction(
+        const ShapeElement& arc,
+        const Point& target_direction)
+{
+    LengthDbl radius = distance(arc.center, arc.start);
+    return point_at_tangent_direction(arc.center, radius, arc.orientation, target_direction);
+}
+
+/**
+ * True if 'direction' lies strictly between arc's start and end tangent
+ * directions (i.e. strictly inside the open span, not at either endpoint).
+ *
+ * Since every arc handled here comes from decompose_into_basic_shapes'
+ * CircularSegment (span < 180°), a direction is strictly inside iff turning
+ * CCW from the start tangent to 'direction' is a positive turn, and turning
+ * CCW from 'direction' to the end tangent is also a positive turn -- two
+ * plain cross-product sign tests, no wraparound handling needed precisely
+ * because the span cannot reach 180°.
+ */
+bool direction_strictly_inside_arc(
+        const ShapeElement& arc,
+        const Point& direction)
+{
+    Point tangent_start = arc.tangent(arc.start);
+    Point tangent_end = arc.tangent(arc.end);
+    LengthDbl cross_1 = tangent_start.x * direction.y - tangent_start.y * direction.x;
+    LengthDbl cross_2 = direction.x * tangent_end.y - direction.y * tangent_end.x;
+    return strictly_greater(cross_1, 0.0) && strictly_greater(cross_2, 0.0);
+}
+
+/**
+ * Split 'arc' into consecutive sub-arc pieces at every direction in
+ * 'target_directions' (given in the arc's own local frame) that falls
+ * strictly inside its span, ordered along the arc from its own start to its
+ * own end. Returns {arc} unchanged if none do.
+ */
+std::vector<ShapeElement> split_arc_into_pieces(
+        const ShapeElement& arc,
+        const std::vector<Point>& target_directions)
+{
+    std::vector<Point> split_points;
+    for (const Point& direction: target_directions)
+        if (direction_strictly_inside_arc(arc, direction))
+            split_points.push_back(point_at_tangent_direction(arc, direction));
+
+    if (split_points.empty())
+        return {arc};
+
+    std::sort(
+            split_points.begin(),
+            split_points.end(),
+            [&arc](const Point& p1, const Point& p2)
+            {
+                return arc.length(p1) < arc.length(p2);
+            });
+
+    std::vector<ShapeElement> pieces;
+    Point piece_start = arc.start;
+    for (const Point& split_point: split_points) {
+        if (equal(piece_start, split_point))
+            continue;
+        pieces.push_back(arc.extract(piece_start, split_point));
+        piece_start = split_point;
+    }
+    if (!equal(piece_start, arc.end))
+        pieces.push_back(arc.extract(piece_start, arc.end));
+    // All split points coincided with piece_start (degenerate/duplicate
+    // directions): fall back to the arc unsplit rather than an empty list.
+    if (pieces.empty())
+        return {arc};
+    return pieces;
+}
+
+/**
+ * Build the final ordered element list for one side of the merge (fixed or
+ * orbiting): identical to 'elements' unless it contains a CircularArc, in
+ * which case that arc is replaced in place by pieces pre-split at every
+ * critical direction contributed by the *other* side -- each of its plain
+ * edges' own tangent direction, plus (if it has one) its own arc's start and
+ * end tangents.
+ *
+ * This has to happen up front, before the main merge loop runs, rather than
+ * relying purely on reactively splitting an arc against whichever direction
+ * the loop happens to be comparing it to at the time: the loop only ever
+ * looks at each side's *current* element, so if the arc is not the first
+ * element of its shape (e.g. decompose_into_basic_shapes' circular segment
+ * starts with its chord instead, depending on which point ends up
+ * bottom/top-most), some of the other side's edges can be fully consumed
+ * against something else entirely before the arc ever becomes current --
+ * permanently missing a split their direction should have triggered.
+ *
+ * 'negate_self'/'negate_other' select which of 'elements'/'other_elements'
+ * is the orbiting side, whose directions get negated for output space (see
+ * EdgeCursor below); both direction sets need to end up expressed in the
+ * *arc's own local frame* to be tested/split against it.
+ */
+std::vector<ShapeElement> presplit_elements(
+        const std::vector<ShapeElement>& elements,
+        bool negate_self,
+        const std::vector<ShapeElement>& other_elements,
+        bool negate_other)
+{
+    ElementPos arc_pos = -1;
+    for (ElementPos i = 0; i < (ElementPos)elements.size(); ++i) {
+        if (elements[i].type == ShapeElementType::CircularArc) {
+            arc_pos = i;
+            break;
+        }
+    }
+    if (arc_pos == -1)
+        return elements;
+
+    std::vector<Point> critical_directions;
+    for (const ShapeElement& other: other_elements) {
+        Point d_start = other.tangent(other.start);
+        if (negate_other)
+            d_start = {-d_start.x, -d_start.y};
+        if (negate_self)
+            d_start = {-d_start.x, -d_start.y};
+        critical_directions.push_back(d_start);
+        if (other.type == ShapeElementType::CircularArc) {
+            Point d_end = other.tangent(other.end);
+            if (negate_other)
+                d_end = {-d_end.x, -d_end.y};
+            if (negate_self)
+                d_end = {-d_end.x, -d_end.y};
+            critical_directions.push_back(d_end);
+        }
+    }
+
+    // Also always split at the global tangent-order minimum direction (1,0)
+    // [negated to (-1,0) in local frame if this is the orbiting side]: if
+    // the arc's span straddles it, the piece starting exactly there needs
+    // to exist so the start-position selection below can find it. Without
+    // this, an arc whose span straddles that direction can undercut every
+    // other candidate's own start direction (its tangent dips below all of
+    // them partway through, past the comparator's wraparound point) without
+    // any element actually starting there for the selection to pick.
+    critical_directions.push_back(negate_self? Point{-1.0, 0.0}: Point{1.0, 0.0});
+
+    std::vector<ShapeElement> pieces = split_arc_into_pieces(elements[arc_pos], critical_directions);
+
+    std::vector<ShapeElement> result;
+    result.reserve(elements.size() - 1 + pieces.size());
+    for (ElementPos i = 0; i < (ElementPos)elements.size(); ++i) {
+        if (i != arc_pos) {
+            result.push_back(elements[i]);
+        } else {
+            for (const ShapeElement& piece: pieces)
+                result.push_back(piece);
+        }
+    }
+    return result;
+}
+
+/**
+ * Incremental cursor over one shape's (already rotated to start at the
+ * chosen start position) element sequence, used to drive the merge loop
+ * below. 'negate' is true for the orbiting side: every direction/point
+ * query already accounts for tracing -orbiting_shape instead of
+ * orbiting_shape, so callers never need to negate anything themselves.
+ */
+struct EdgeCursor
+{
+    const std::vector<ShapeElement>* elements = nullptr;
+    ElementPos next_pos = 0;
+    bool negate = false;
+
+    // The element currently at the front of the cursor (already popped from
+    // 'elements' conceptually; may be a suffix of an original element after
+    // a partial consumption). Only meaningful if has_current() is true.
+    ShapeElement current;
+    bool has_current_ = false;
+
+    bool has_current() const { return has_current_; }
+
+    void init()
+    {
+        if (elements != nullptr && !elements->empty()) {
+            current = (*elements)[0];
+            next_pos = 1;
+            has_current_ = true;
+        }
+    }
+
+    void advance()
+    {
+        if (elements != nullptr && next_pos < (ElementPos)elements->size()) {
+            current = (*elements)[next_pos++];
+            has_current_ = true;
+        } else {
+            has_current_ = false;
+        }
+    }
+
+    /** Tangent direction at the current element's start, in output space (negated for orbiting). */
+    Point start_direction() const
+    {
+        Point t = current.tangent(current.start);
+        return negate? Point{-t.x, -t.y}: t;
+    }
+
+    /** Tangent direction at the current element's end, in output space (negated for orbiting). */
+    Point end_direction() const
+    {
+        Point t = current.tangent(current.end);
+        return negate? Point{-t.x, -t.y}: t;
+    }
+
+    /** Build the (possibly negated) placed copy of a local sub-element, shifted so its start is at 'placed_start'. */
+    ShapeElement place(
+            const ShapeElement& local_element,
+            const Point& placed_start) const
+    {
+        ShapeElement placed;
+        if (!negate) {
+            placed = local_element;
+        } else if (local_element.type == ShapeElementType::LineSegment) {
+            placed = build_line_segment(
+                    {-local_element.start.x, -local_element.start.y},
+                    {-local_element.end.x, -local_element.end.y});
+        } else {
+            placed = build_circular_arc(
+                    {-local_element.start.x, -local_element.start.y},
+                    {-local_element.end.x, -local_element.end.y},
+                    {-local_element.center.x, -local_element.center.y},
+                    local_element.orientation);
+        }
+        Point shift = placed_start - placed.start;
+        placed.shift(shift.x, shift.y);
+        return placed;
+    }
+
+    /**
+     * Split the current element (which must be a CircularArc) at the point
+     * whose tangent direction (in output/negated space) is 'target_direction',
+     * which must be strictly inside its current span. Returns the local
+     * (unplaced) prefix sub-element; the cursor's current element becomes the
+     * local (unplaced) remainder (still not advanced).
+     */
+    ShapeElement split_current_at(const Point& target_direction)
+    {
+        Point local_target = negate?
+            Point{-target_direction.x, -target_direction.y}:
+            target_direction;
+        Point split_point = point_at_tangent_direction(current, local_target);
+        ShapeElement prefix = current.extract(current.start, split_point);
+        current = current.extract(split_point, current.end);
+        return prefix;
+    }
+};
+
+/** Append 'element' to 'result' and update 'current_vertex', unless it is degenerate (zero length). */
+void append_if_nondegenerate(
+        std::vector<ShapeElement>& result,
+        Point& current_vertex,
+        const ShapeElement& element)
+{
+    if (!equal(element.start, element.end)) {
+        result.push_back(element);
+        current_vertex = element.end;
+    }
+}
+
+/** Consume the cursor's current element in full (no split), appending it to the result. */
+void consume_whole(
+        EdgeCursor& cursor,
+        std::vector<ShapeElement>& result,
+        Point& current_vertex)
+{
+    ShapeElement placed = cursor.place(cursor.current, current_vertex);
+    append_if_nondegenerate(result, current_vertex, placed);
+    cursor.advance();
+}
+
+/**
+ * Consume the cursor's current element up to 'other_direction' (a direction
+ * in output/negated space): if the current element is a CircularArc whose
+ * span strictly contains that direction, split it there, append only the
+ * prefix, and leave the (unplaced) remainder as the new current element
+ * (cursor not advanced). Otherwise the whole element is consumed as usual.
+ */
+void consume_up_to(
+        EdgeCursor& cursor,
+        const Point& other_direction,
+        std::vector<ShapeElement>& result,
+        Point& current_vertex)
+{
+    if (cursor.current.type == ShapeElementType::CircularArc
+            && direction_strictly_inside_arc(
+                    cursor.current,
+                    cursor.negate? Point{-other_direction.x, -other_direction.y}: other_direction)) {
+        ShapeElement local_prefix = cursor.split_current_at(other_direction);
+        ShapeElement placed = cursor.place(local_prefix, current_vertex);
+        append_if_nondegenerate(result, current_vertex, placed);
+    } else {
+        consume_whole(cursor, result, current_vertex);
+    }
+}
+
+/**
+ * Handle the case where both cursors currently point at a CircularArc
+ * element (only possible when both input shapes are CircularSegment basic
+ * shapes). If their tangent-direction spans don't overlap, the earlier one
+ * is consumed alone as usual. If they do overlap, the two circles are summed
+ * over the overlapping direction range -- for two circular arcs sharing a
+ * range of tangent (equivalently: normal) directions, their Minkowski sum
+ * over that range is itself a circular arc: center = sum of centers, radius
+ * = sum of radii, same direction range. Any non-overlapping prefix/suffix on
+ * either side is emitted separately as a lone arc contribution.
+ */
+void handle_arc_arc(
+        EdgeCursor& fixed,
+        EdgeCursor& orbiting,
+        std::vector<ShapeElement>& result,
+        Point& current_vertex)
+{
+    Point f_start = fixed.start_direction();
+    Point f_end = fixed.end_direction();
+    Point o_start = orbiting.start_direction();
+    Point o_end = orbiting.end_direction();
+
+    // f_span/o_span: each side's own tangent span, in (0, pi) -- guaranteed
+    // small since decompose_into_basic_shapes never produces an arc spanning
+    // >= 180 degrees, and that guarantee survives negation (a uniform shift
+    // changes where the pair sits, not their relative separation).
+    //
+    // strictly_lesser_angle (used elsewhere in this file) is NOT safe here:
+    // it is a *global* total order with a fixed branch cut at 0/360 degrees.
+    // Negating orbiting's tangent directions shifts each by +180 degrees
+    // independently; if the pre-negation pair straddled that fixed cut, the
+    // shift can flip their order under that comparator even though the
+    // underlying arc itself is perfectly well-formed. angle_radian, being
+    // relative to whichever vector is passed as its first argument rather
+    // than a fixed global reference, has no such cut and is what all the
+    // comparisons below use instead.
+    Angle f_span = angle_radian(f_start, f_end);
+    Angle o_span = angle_radian(o_start, o_end);
+
+    // Signed (shortest-way) CCW offset of o_start relative to f_start, in
+    // (-pi, pi].
+    Angle d_start = angle_radian(f_start, o_start);
+    if (strictly_greater(d_start, M_PI))
+        d_start -= 2.0 * M_PI;
+
+    // No overlap: o's span starts at/after f's end (d_start >= f_span), or
+    // f's span starts at/after o's end (-d_start >= o_span).
+    if (!strictly_lesser(d_start, f_span)) {
+        consume_whole(fixed, result, current_vertex);
+        return;
+    }
+    if (!strictly_lesser(-d_start, o_span)) {
+        consume_whole(orbiting, result, current_vertex);
+        return;
+    }
+
+    // Overlap exists. Peel off any lone prefix (at most one side has one:
+    // whichever start has the strictly later, i.e. positive-offset, side).
+    bool fixed_has_prefix = strictly_greater(d_start, 0.0);
+    bool orbiting_has_prefix = strictly_lesser(d_start, 0.0);
+    Point overlap_start = fixed_has_prefix? o_start: f_start;
+    if (fixed_has_prefix)
+        consume_up_to(fixed, overlap_start, result, current_vertex);
+    if (orbiting_has_prefix)
+        consume_up_to(orbiting, overlap_start, result, current_vertex);
+
+    // Both cursors now start exactly at overlap_start. Determine how far the
+    // overlap extends (same local/signed reasoning, now relative to the two
+    // end directions), splitting off whichever side's remainder is longer.
+    Angle d_end = angle_radian(f_end, o_end);
+    if (strictly_greater(d_end, M_PI))
+        d_end -= 2.0 * M_PI;
+    bool fixed_has_suffix = strictly_lesser(d_end, 0.0);
+    bool orbiting_has_suffix = strictly_greater(d_end, 0.0);
+    Point overlap_end = fixed_has_suffix? o_end: f_end;
+
+    ShapeElement fixed_local_piece = fixed.current;
+    bool fixed_will_advance = !fixed_has_suffix;
+    if (fixed_has_suffix)
+        fixed_local_piece = fixed.split_current_at(overlap_end);
+    ShapeElement orbiting_local_piece = orbiting.current;
+    bool orbiting_will_advance = !orbiting_has_suffix;
+    if (orbiting_has_suffix)
+        orbiting_local_piece = orbiting.split_current_at(overlap_end);
+
+    // Sum the two (local, unplaced) overlap pieces into a single arc.
+    LengthDbl fixed_radius = distance(fixed_local_piece.center, fixed_local_piece.start);
+    LengthDbl orbiting_radius = distance(orbiting_local_piece.center, orbiting_local_piece.start);
+    Point orbiting_neg_center = {-orbiting_local_piece.center.x, -orbiting_local_piece.center.y};
+    Point orbiting_neg_start = {-orbiting_local_piece.start.x, -orbiting_local_piece.start.y};
+    Point combined_center = current_vertex
+        + (fixed_local_piece.center - fixed_local_piece.start)
+        + (orbiting_neg_center - orbiting_neg_start);
+    LengthDbl combined_radius = fixed_radius + orbiting_radius;
+    Point combined_end = point_at_tangent_direction(
+            combined_center, combined_radius, ShapeElementOrientation::Anticlockwise, overlap_end);
+    ShapeElement combined = build_circular_arc(
+            current_vertex, combined_end, combined_center, ShapeElementOrientation::Anticlockwise);
+    append_if_nondegenerate(result, current_vertex, combined);
+
+    // If not advancing, the cursor's .current was already updated to the
+    // (unplaced) post-overlap remainder by split_current_at above.
+    if (fixed_will_advance)
+        fixed.advance();
+    if (orbiting_will_advance)
+        orbiting.advance();
+}
+
+}  // namespace
 
 Shape shape::no_fit_polygon(
         const Shape& fixed_shape,
         const Shape& orbiting_shape)
 {
-    if (!fixed_shape.is_polygon()) {
-        throw std::runtime_error(
-                FUNC_SIGNATURE + "; "
-                "fixed_shape is not a polygon.");
-    }
-    if (!orbiting_shape.is_polygon()) {
-        throw std::runtime_error(
-                FUNC_SIGNATURE + "; "
-                "orbiting_shape is not a polygon.");
-    }
     if (!fixed_shape.is_convex()) {
         throw std::runtime_error(
                 FUNC_SIGNATURE + "; "
@@ -30,145 +458,194 @@ Shape shape::no_fit_polygon(
                 FUNC_SIGNATURE + "; "
                 "orbiting_shape is not convex.");
     }
+    // The algorithm below merges each shape's own element sequence with the
+    // other's, splitting an arc reactively whenever the other side's current
+    // direction falls inside it; with more than one arc per shape the
+    // "at most one arc in progress per side" assumption breaks down.
+    // decompose_into_basic_shapes' CircularSegment (the intended source of
+    // arc-containing input here) always has exactly one.
+    auto count_arcs = [](const Shape& s) {
+        ElementPos n = 0;
+        for (const ShapeElement& e: s.elements)
+            if (e.type == ShapeElementType::CircularArc)
+                ++n;
+        return n;
+    };
+    if (count_arcs(fixed_shape) > 1) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + "; "
+                "fixed_shape has more than one circular arc.");
+    }
+    if (count_arcs(orbiting_shape) > 1) {
+        throw std::runtime_error(
+                FUNC_SIGNATURE + "; "
+                "orbiting_shape has more than one circular arc.");
+    }
 
-    // Find the bottom-most vertex of fixed_shape (min y, then min x for ties).
-    // Starting the edge sequence here ensures the first outgoing edge
-    // has angle in [0°, 180°), suitable for the angular merge below.
+    // Pre-split each side's arc (if any), in its original (unrotated) index
+    // order, against the other side's critical directions -- see
+    // presplit_elements' comment for why this can't be done reactively
+    // during the merge below, and for why it also always splits at the
+    // global tangent-order minimum direction. Both calls read from the
+    // shapes' own original element lists (not from each other's already-
+    // split result) so the two splits don't depend on each other's outcome.
+    std::vector<ShapeElement> fixed_elements = presplit_elements(
+            fixed_shape.elements, false, orbiting_shape.elements, true);
+    std::vector<ShapeElement> orbiting_elements = presplit_elements(
+            orbiting_shape.elements, true, fixed_shape.elements, false);
+
+    // Find the element whose start tangent direction is the global minimum
+    // (per strictly_lesser_angle's total order) among fixed_elements, and
+    // the element whose *negated* start tangent direction is the global
+    // minimum among orbiting_elements. Starting the traced sequence at that
+    // element guarantees every subsequent element's direction increases
+    // monotonically all the way around before wrapping back, exactly once,
+    // to close the loop -- which the merge below relies on.
+    //
+    // For a pure polygon this is equivalent to (and was previously
+    // implemented as) picking the bottom-most vertex for fixed_shape / the
+    // top-most vertex for orbiting_shape: a convex polygon's tangent
+    // direction is minimal exactly at the edge leaving its bottom-most
+    // point. That geometric shortcut is not reliable once a shape can
+    // contain a CircularArc element, since an arc's own tangent sweeps
+    // continuously across its span and could dip below every other
+    // element's own start direction partway through without any element
+    // actually starting there -- which is exactly why presplit_elements
+    // above always splits an arc at the global minimum direction (1, 0)
+    // too, guaranteeing there is always an element that starts exactly
+    // there for this search to find.
     ElementPos fixed_start_pos = 0;
     for (ElementPos fixed_pos = 1;
-            fixed_pos < (ElementPos)fixed_shape.elements.size();
+            fixed_pos < (ElementPos)fixed_elements.size();
             ++fixed_pos) {
-        const Point& point = fixed_shape.elements[fixed_pos].start;
-        const Point& best = fixed_shape.elements[fixed_start_pos].start;
-        if (strictly_lesser(point.y, best.y)
-                || (equal(point.y, best.y)
-                    && strictly_lesser(point.x, best.x))) {
+        const ShapeElement& element = fixed_elements[fixed_pos];
+        const ShapeElement& best = fixed_elements[fixed_start_pos];
+        if (strictly_lesser_angle(
+                element.tangent(element.start),
+                best.tangent(best.start))) {
             fixed_start_pos = fixed_pos;
         }
     }
 
-    // Find the top-most vertex of orbiting_shape (max y, then max x for ties).
-    // Negating it gives the bottom-most vertex of −orbiting_shape
-    // (= orbiting_shape rotated 180°), which also has its first outgoing
-    // edge in [0°, 180°).
     ElementPos orbiting_start_pos = 0;
     for (ElementPos orbiting_pos = 1;
-            orbiting_pos < (ElementPos)orbiting_shape.elements.size();
+            orbiting_pos < (ElementPos)orbiting_elements.size();
             ++orbiting_pos) {
-        const Point& point = orbiting_shape.elements[orbiting_pos].start;
-        const Point& best = orbiting_shape.elements[orbiting_start_pos].start;
-        if (strictly_greater(point.y, best.y)
-                || (equal(point.y, best.y)
-                    && strictly_greater(point.x, best.x))) {
+        const ShapeElement& element = orbiting_elements[orbiting_pos];
+        const ShapeElement& best = orbiting_elements[orbiting_start_pos];
+        Point element_dir = element.tangent(element.start);
+        Point best_dir = best.tangent(best.start);
+        if (strictly_lesser_angle(
+                Point{-element_dir.x, -element_dir.y},
+                Point{-best_dir.x, -best_dir.y})) {
             orbiting_start_pos = orbiting_pos;
         }
     }
 
     // Starting vertex of the NFP: bottom of fixed minus top of orbiting.
-    const Point nfp_start = fixed_shape.elements[fixed_start_pos].start
-        - orbiting_shape.elements[orbiting_start_pos].start;
+    const Point nfp_start = fixed_elements[fixed_start_pos].start
+        - orbiting_elements[orbiting_start_pos].start;
 
-    // Build the edge-vector sequences for the angular merge.
-    //
-    // Edges of fixed_shape in CCW order starting from fixed_start_pos:
-    //   edges_fixed[edge_index] =
-    //     fixed_shape.elements[(fixed_start_pos + edge_index) % m].end
-    //   − fixed_shape.elements[(fixed_start_pos + edge_index) % m].start
-    //
-    // Edges of −orbiting_shape in CCW order starting from the negated top vertex:
-    //   Since −orbiting_shape = rotate(orbiting_shape, 180°) it is also CCW.
-    //   Going CCW from the negated top vertex follows the same index direction,
-    //   so each edge of −orbiting_shape is the negation of the corresponding
-    //   edge of orbiting_shape (offset by orbiting_start_pos):
-    //   edges_neg_orbiting[edge_index] =
-    //     −(orbiting_shape.elements[(orbiting_start_pos + edge_index) % n].end
-    //      − orbiting_shape.elements[(orbiting_start_pos + edge_index) % n].start)
-    const ElementPos fixed_num_elements
-        = (ElementPos)fixed_shape.elements.size();
-    const ElementPos orbiting_num_elements
-        = (ElementPos)orbiting_shape.elements.size();
+    const ElementPos fixed_num_elements = (ElementPos)fixed_elements.size();
+    const ElementPos orbiting_num_elements = (ElementPos)orbiting_elements.size();
 
-    std::vector<Point> edges_fixed(fixed_num_elements);
-    for (ElementPos edge_index = 0; edge_index < fixed_num_elements; ++edge_index) {
-        const ElementPos element_pos = (fixed_start_pos + edge_index) % fixed_num_elements;
-        edges_fixed[edge_index] = fixed_shape.elements[element_pos].end
-            - fixed_shape.elements[element_pos].start;
+    {
+        std::vector<ShapeElement> fixed_elements_rotated(fixed_num_elements);
+        for (ElementPos i = 0; i < fixed_num_elements; ++i)
+            fixed_elements_rotated[i] = fixed_elements[(fixed_start_pos + i) % fixed_num_elements];
+        fixed_elements = std::move(fixed_elements_rotated);
+    }
+    {
+        std::vector<ShapeElement> orbiting_elements_rotated(orbiting_num_elements);
+        for (ElementPos i = 0; i < orbiting_num_elements; ++i)
+            orbiting_elements_rotated[i] = orbiting_elements[(orbiting_start_pos + i) % orbiting_num_elements];
+        orbiting_elements = std::move(orbiting_elements_rotated);
     }
 
-    std::vector<Point> edges_neg_orbiting(orbiting_num_elements);
-    for (ElementPos edge_index = 0; edge_index < orbiting_num_elements; ++edge_index) {
-        const ElementPos element_pos
-            = (orbiting_start_pos + edge_index) % orbiting_num_elements;
-        const Point edge = orbiting_shape.elements[element_pos].end
-            - orbiting_shape.elements[element_pos].start;
-        edges_neg_orbiting[edge_index] = {-edge.x, -edge.y};
-    }
+    EdgeCursor fixed_cursor;
+    fixed_cursor.elements = &fixed_elements;
+    fixed_cursor.negate = false;
+    fixed_cursor.init();
 
-    // Merge both edge sequences in non-decreasing angular order (rotating
-    // calipers) and trace the Minkowski-sum polygon.
+    EdgeCursor orbiting_cursor;
+    orbiting_cursor.elements = &orbiting_elements;
+    orbiting_cursor.negate = true;
+    orbiting_cursor.init();
+
+    // Merge both element sequences in non-decreasing angular (tangent
+    // direction) order (rotating calipers) and trace the Minkowski-sum
+    // shape. A CircularArc element contributes a continuous range of
+    // directions (from its start to its end tangent) instead of a single
+    // one; whenever the other side's current direction falls strictly
+    // inside that range, the arc is split there so only the relevant prefix
+    // is merged in, leaving the remainder for later iterations. Two arcs
+    // active on both sides at once (only possible when both original shapes
+    // are circular segments) are summed over their overlapping range -- see
+    // handle_arc_arc.
     //
     // When two edges have the same direction (parallel) they are both added
     // in sequence, producing collinear intermediate vertices that are removed
     // by remove_aligned_vertices at the end.
-    std::vector<Point> nfp_vertices;
-    nfp_vertices.reserve(fixed_num_elements + orbiting_num_elements);
-    nfp_vertices.push_back(nfp_start);
-
+    std::vector<ShapeElement> result;
+    result.reserve(fixed_num_elements + orbiting_num_elements);
     Point current_vertex = nfp_start;
-    ElementPos fixed_edge_pos = 0;
-    ElementPos orbiting_edge_pos = 0;
 
-    while (fixed_edge_pos < fixed_num_elements
-            || orbiting_edge_pos < orbiting_num_elements) {
-        if (fixed_edge_pos >= fixed_num_elements) {
-            current_vertex = current_vertex + edges_neg_orbiting[orbiting_edge_pos++];
-        } else if (orbiting_edge_pos >= orbiting_num_elements) {
-            current_vertex = current_vertex + edges_fixed[fixed_edge_pos++];
-        } else if (strictly_lesser_angle(
-                edges_fixed[fixed_edge_pos],
-                edges_neg_orbiting[orbiting_edge_pos])) {
-            current_vertex = current_vertex + edges_fixed[fixed_edge_pos++];
-        } else if (strictly_lesser_angle(
-                edges_neg_orbiting[orbiting_edge_pos],
-                edges_fixed[fixed_edge_pos])) {
-            current_vertex = current_vertex + edges_neg_orbiting[orbiting_edge_pos++];
-        } else {
-            // Parallel edges: advance fixed first, then negated orbiting.
-            current_vertex = current_vertex + edges_fixed[fixed_edge_pos++];
-            nfp_vertices.push_back(current_vertex);
-            current_vertex = current_vertex + edges_neg_orbiting[orbiting_edge_pos++];
+    while (fixed_cursor.has_current() || orbiting_cursor.has_current()) {
+        if (!orbiting_cursor.has_current()) {
+            consume_whole(fixed_cursor, result, current_vertex);
+            continue;
+        }
+        if (!fixed_cursor.has_current()) {
+            consume_whole(orbiting_cursor, result, current_vertex);
+            continue;
         }
 
-        // Only push if we have not yet closed the polygon.
-        if (fixed_edge_pos < fixed_num_elements
-                || orbiting_edge_pos < orbiting_num_elements)
-            nfp_vertices.push_back(current_vertex);
-    }
-    // After all edges, current_vertex == nfp_start (the polygon is closed).
+        bool fixed_is_arc = fixed_cursor.current.type == ShapeElementType::CircularArc;
+        bool orbiting_is_arc = orbiting_cursor.current.type == ShapeElementType::CircularArc;
 
-    // Build the result Shape from consecutive vertex pairs.
-    Shape result;
-    result.elements.reserve(nfp_vertices.size());
-    for (ElementPos vertex_pos = 0;
-            vertex_pos < (ElementPos)nfp_vertices.size();
-            ++vertex_pos) {
-        ShapeElement element;
-        element.type = ShapeElementType::LineSegment;
-        element.start = nfp_vertices[vertex_pos];
-        element.end = nfp_vertices[(vertex_pos + 1) % nfp_vertices.size()];
-        result.elements.push_back(element);
-    }
+        if (fixed_is_arc && orbiting_is_arc) {
+            handle_arc_arc(fixed_cursor, orbiting_cursor, result, current_vertex);
+            continue;
+        }
 
-    // Remove collinear vertices introduced by parallel-edge pairs.
-    return remove_aligned_vertices(result).second;
+        Point fixed_dir = fixed_cursor.start_direction();
+        Point orbiting_dir = orbiting_cursor.start_direction();
+
+        if (strictly_lesser_angle(fixed_dir, orbiting_dir)) {
+            consume_up_to(fixed_cursor, orbiting_dir, result, current_vertex);
+        } else if (strictly_lesser_angle(orbiting_dir, fixed_dir)) {
+            consume_up_to(orbiting_cursor, fixed_dir, result, current_vertex);
+        } else if (!fixed_is_arc && !orbiting_is_arc) {
+            // Tied plain edges: fixed first, then orbiting (matches the
+            // pre-arc-support behavior exactly, just spread over two loop
+            // iterations instead of one: fixed's next element strictly
+            // exceeds this tie, so orbiting is picked up correctly next).
+            consume_whole(fixed_cursor, result, current_vertex);
+        } else if (fixed_is_arc) {
+            // Tie at the arc's own start: the plain edge (a single point,
+            // contributing nothing beyond it) goes first; the arc, which is
+            // only just starting to sweep past this direction, goes next.
+            consume_whole(orbiting_cursor, result, current_vertex);
+        } else {
+            consume_whole(fixed_cursor, result, current_vertex);
+        }
+    }
+    // After all edges, current_vertex == nfp_start (the shape is closed).
+
+    Shape result_shape;
+    result_shape.elements = std::move(result);
+
+    // Remove collinear vertices introduced by parallel-edge pairs (arcs are
+    // left untouched by this cleanup).
+    return remove_aligned_vertices(result_shape).second;
 }
 
 MultiShapeWithHoles shape::no_fit_polygon(
         const ShapeWithHoles& fixed_shape,
         const ShapeWithHoles& orbiting_shape)
 {
-    std::vector<Shape> fixed_parts = compute_convex_partition(fixed_shape);
-    std::vector<Shape> orbiting_parts = compute_convex_partition(orbiting_shape);
+    std::vector<BasicShape> fixed_parts = decompose_into_basic_shapes(fixed_shape).basic_shapes;
+    std::vector<BasicShape> orbiting_parts = decompose_into_basic_shapes(orbiting_shape).basic_shapes;
 
     // Union per fixed_part group first, instead of unioning all
     // fixed_parts.size() * orbiting_parts.size() convex-convex NFP pieces in
@@ -178,11 +655,11 @@ MultiShapeWithHoles shape::no_fit_polygon(
     // groups before the final union only has to merge the (typically far
     // fewer) per-group results.
     std::vector<ShapeWithHoles> group_unions;
-    for (const Shape& fixed_part: fixed_parts) {
+    for (const BasicShape& fixed_part: fixed_parts) {
         std::vector<ShapeWithHoles> nfp_parts;
         nfp_parts.reserve(orbiting_parts.size());
-        for (const Shape& orbiting_part: orbiting_parts) {
-            Shape convex_nfp = no_fit_polygon(fixed_part, orbiting_part);
+        for (const BasicShape& orbiting_part: orbiting_parts) {
+            Shape convex_nfp = no_fit_polygon(fixed_part.shape, orbiting_part.shape);
             nfp_parts.push_back({convex_nfp, {}});
         }
         for (const ShapeWithHoles& swh: compute_union(nfp_parts).shapes_with_holes)

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -1307,23 +1307,49 @@ bool Shape::contains(
                 //std::cout << "intersection " << intersection.to_string() << std::endl;
                 if (intersection == element.start) {
                     Angle start_angle = angle_radian(element.start - element.center);
-                    //std::cout << "start_angle " << start_angle
-                    //    << " M_PI / 2 " << M_PI / 2
-                    //    << " 3 * M_PI / 2 " << 3 * M_PI / 2
-                    //    << std::endl;
-                    bool start_upward = (element.orientation == ShapeElementOrientation::Anticlockwise)?
-                        (strictly_lesser(start_angle, M_PI / 2) || !strictly_lesser(start_angle, 3 * M_PI / 2)):
-                        (strictly_greater(start_angle, M_PI / 2) && !strictly_greater(start_angle, 3 * M_PI / 2));
-                    //std::cout << "start_upward " << start_upward << std::endl;
+                    bool start_upward;
+                    if (equal(start_angle, M_PI / 2)) {
+                        // element.start is exactly the circle's own topmost
+                        // point: y has a strict local maximum there, so
+                        // moving away along the arc -- whichever direction,
+                        // regardless of orientation or how far the arc
+                        // continues -- always decreases y. The angle-based
+                        // formula below is undefined here (it only makes
+                        // sense when the tangent has a definite non-zero
+                        // vertical component), so this case is handled
+                        // directly instead of through it.
+                        start_upward = false;
+                    } else if (equal(start_angle, 3 * M_PI / 2)) {
+                        // Symmetric case at the circle's bottommost point (a
+                        // strict local minimum): moving away always
+                        // increases y.
+                        start_upward = true;
+                    } else {
+                        start_upward = (element.orientation == ShapeElementOrientation::Anticlockwise)?
+                            (strictly_lesser(start_angle, M_PI / 2) || !strictly_lesser(start_angle, 3 * M_PI / 2)):
+                            (strictly_greater(start_angle, M_PI / 2) && !strictly_greater(start_angle, 3 * M_PI / 2));
+                    }
                     if (start_upward)
                         intersection_count++;
                 }
                 if (intersection == element.end) {
                     Angle end_angle = angle_radian(element.end - element.center);
-                    bool end_upward = (element.orientation == ShapeElementOrientation::Anticlockwise)?
-                        (strictly_lesser(end_angle, M_PI / 2) || !strictly_lesser(end_angle, 3 * M_PI / 2)):
-                        (!strictly_lesser(end_angle, M_PI / 2) && strictly_lesser(end_angle, 3 * M_PI / 2));
-                    //std::cout << "end_upward " << end_upward << std::endl;
+                    bool end_upward;
+                    if (equal(end_angle, M_PI / 2)) {
+                        // element.end is exactly the circle's own topmost
+                        // point (a strict local maximum): approaching it
+                        // along the arc, from whichever side, is always
+                        // ascending right up to it.
+                        end_upward = true;
+                    } else if (equal(end_angle, 3 * M_PI / 2)) {
+                        // Symmetric case at the bottommost point: always
+                        // descending right up to it.
+                        end_upward = false;
+                    } else {
+                        end_upward = (element.orientation == ShapeElementOrientation::Anticlockwise)?
+                            (strictly_lesser(end_angle, M_PI / 2) || !strictly_lesser(end_angle, 3 * M_PI / 2)):
+                            (!strictly_lesser(end_angle, M_PI / 2) && strictly_lesser(end_angle, 3 * M_PI / 2));
+                    }
                     if (!end_upward)
                         intersection_count++;
                 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(Shape_shape_test PRIVATE
     approximation_test.cpp
     simplification_test.cpp
     convex_partition_test.cpp
+    basic_shapes_test.cpp
     rasterization_test.cpp
     no_fit_polygon_test.cpp)
 target_include_directories(Shape_shape_test PRIVATE

--- a/test/basic_shapes_test.cpp
+++ b/test/basic_shapes_test.cpp
@@ -1,0 +1,185 @@
+#include "shape/basic_shapes.hpp"
+
+#include "shape/elements_intersections.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace shape;
+
+TEST(BasicShapesTest, PurePolygonProducesNoCircularSegment)
+{
+    Shape s = build_shape({{0, 0}, {1, 0}, {1, 1}, {0, 1}});
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    ASSERT_EQ(decomp.basic_shapes.size(), 1);
+    EXPECT_EQ(decomp.basic_shapes[0].type, BasicShapeType::ConvexPolygon);
+}
+
+TEST(BasicShapesTest, TriangleWithInflatedHypotenuse)
+{
+    // Right triangle (0,0)-(1,0)-(0,1) where the hypotenuse is replaced by a
+    // convex arc bulging outward, centered on the right-angle vertex (0,0)
+    // (both (1,0) and (0,1) are at distance 1 from it, a valid arc).
+    Shape s = build_shape({{0, 0}, {1, 0}, {0, 0, 1}, {0, 1}});
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    ASSERT_EQ(decomp.basic_shapes.size(), 2);
+
+    Counter segment_pos = -1;
+    Counter polygon_pos = -1;
+    for (Counter basic_shape_pos = 0;
+            basic_shape_pos < (Counter)decomp.basic_shapes.size();
+            ++basic_shape_pos) {
+        if (decomp.basic_shapes[basic_shape_pos].type == BasicShapeType::CircularSegment)
+            segment_pos = basic_shape_pos;
+        else
+            polygon_pos = basic_shape_pos;
+    }
+    ASSERT_NE(segment_pos, -1);
+    ASSERT_NE(polygon_pos, -1);
+
+    const BasicShape& segment = decomp.basic_shapes[segment_pos];
+    EXPECT_NEAR(segment.circle_center.x, 0.0, 1e-9);
+    EXPECT_NEAR(segment.circle_center.y, 0.0, 1e-9);
+    EXPECT_NEAR(segment.circle_radius, 1.0, 1e-9);
+    ASSERT_EQ(segment.shape.elements.size(), 2);
+    EXPECT_EQ(segment.shape.elements[0].type, ShapeElementType::CircularArc);
+    EXPECT_EQ(segment.shape.elements[1].type, ShapeElementType::LineSegment);
+    // The arc element itself must carry the same circle as circle_center/radius.
+    EXPECT_NEAR(segment.shape.elements[0].center.x, segment.circle_center.x, 1e-9);
+    EXPECT_NEAR(segment.shape.elements[0].center.y, segment.circle_center.y, 1e-9);
+    EXPECT_TRUE(segment.shape.is_convex());
+
+    // The remaining polygon must still be the plain right triangle.
+    EXPECT_TRUE(decomp.basic_shapes[polygon_pos].shape.is_convex());
+    for (const ShapeElement& element: decomp.basic_shapes[polygon_pos].shape.elements)
+        EXPECT_EQ(element.type, ShapeElementType::LineSegment);
+}
+
+TEST(BasicShapesTest, ArcOfAtLeast180DegreesIsSubdivided)
+{
+    // A shape whose whole boundary is a single 270-degree arc (plus its
+    // closing chord): must be subdivided since 270 >= 180, so every
+    // resulting CircularSegment must have an arc strictly less than 180.
+    Shape s = build_shape({{1, 0}, {0, 0, 1}, {-1, 0}, {0, 0, 1}, {0, -1}});
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    for (const BasicShape& basic_shape: decomp.basic_shapes) {
+        if (basic_shape.type != BasicShapeType::CircularSegment)
+            continue;
+        const ShapeElement& arc = basic_shape.shape.elements[0];
+        LengthDbl arc_angle = angle_radian(
+                arc.start - arc.center,
+                arc.end - arc.center);
+        EXPECT_LT(arc_angle, M_PI);
+    }
+}
+
+TEST(BasicShapesTest, HoleWithMaterialBulgingIntoIt)
+{
+    // A square with a square hole in the middle, except one edge of the hole
+    // is replaced by a clockwise arc (material bulging into the void, the
+    // hole equivalent of a convex bump), centered above the hole's top edge
+    // so the arc dips down into the hole.
+    ShapeWithHoles s;
+    s.shape = build_shape({{0, 0}, {10, 0}, {10, 10}, {0, 10}});
+    s.holes = {build_shape({{3, 3}, {7, 3}, {7, 7}, {5, 8, -1}, {3, 7}})};
+
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    Counter segment_pos = -1;
+    for (Counter basic_shape_pos = 0;
+            basic_shape_pos < (Counter)decomp.basic_shapes.size();
+            ++basic_shape_pos) {
+        if (decomp.basic_shapes[basic_shape_pos].type == BasicShapeType::CircularSegment) {
+            ASSERT_EQ(segment_pos, -1) << "expected exactly one circular segment";
+            segment_pos = basic_shape_pos;
+        }
+    }
+    ASSERT_NE(segment_pos, -1) << "the clockwise arc in the hole must be cut into a circular segment";
+
+    const BasicShape& segment = decomp.basic_shapes[segment_pos];
+    EXPECT_NEAR(segment.circle_center.x, 5.0, 1e-9);
+    EXPECT_NEAR(segment.circle_center.y, 8.0, 1e-9);
+    EXPECT_NEAR(segment.circle_radius, std::sqrt(5.0), 1e-9);
+    ASSERT_EQ(segment.shape.elements.size(), 2);
+    EXPECT_EQ(segment.shape.elements[0].type, ShapeElementType::CircularArc);
+    // The arc was Clockwise in the hole's own loop (convex-from-material
+    // there), but the standalone segment.shape must itself be a valid
+    // anticlockwise shape, so it is stored reversed here.
+    EXPECT_EQ(segment.shape.elements[0].orientation, ShapeElementOrientation::Anticlockwise);
+
+    // Every basic shape (including the segment itself) must be convex.
+    for (const BasicShape& basic_shape: decomp.basic_shapes)
+        EXPECT_TRUE(basic_shape.shape.is_convex());
+}
+
+TEST(BasicShapesTest, HoleArcSubdividedToAvoidCrossingAnotherHole)
+{
+    // Same bulging hole as above, but a second hole is placed directly in
+    // the path of the first arc's natural chord ((7,7)-(3,7)): if
+    // chord_intersects_boundary only checked the arc's own loop, this chord
+    // would be accepted even though it cuts straight through hole_2.
+    ShapeWithHoles s;
+    s.shape = build_shape({{0, 0}, {10, 0}, {10, 10}, {0, 10}});
+    s.holes = {
+        build_shape({{3, 3}, {7, 3}, {7, 7}, {5, 8, -1}, {3, 7}}),
+        build_shape({{4, 6.5}, {6, 6.5}, {6, 7.5}, {4, 7.5}}),
+    };
+
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    bool found_segment = false;
+    for (const BasicShape& basic_shape: decomp.basic_shapes) {
+        if (basic_shape.type != BasicShapeType::CircularSegment)
+            continue;
+        found_segment = true;
+        ASSERT_EQ(basic_shape.shape.elements.size(), 2);
+        const ShapeElement& chord = basic_shape.shape.elements[1];
+        EXPECT_EQ(chord.type, ShapeElementType::LineSegment);
+        // The chord must not cross hole_2's boundary.
+        for (const ShapeElement& hole_2_element: s.holes[1].elements) {
+            ShapeElementIntersectionsOutput result = compute_intersections(chord, hole_2_element);
+            EXPECT_TRUE(result.proper_intersections.empty());
+            EXPECT_TRUE(result.overlapping_parts.empty());
+        }
+    }
+    EXPECT_TRUE(found_segment);
+}
+
+TEST(BasicShapesTest, HoleArcSubdividedToAvoidTouchingAnotherHolesVertex)
+{
+    // Same bulging hole as above, but hole_2 is now a small triangle with one
+    // vertex sitting exactly on the first arc's natural chord (the
+    // horizontal segment y=7, x in [3,7]) at (5,7): a T-junction touch, not a
+    // crossing, and not at either of the chord's own endpoints ((7,7) and
+    // (3,7)). Per compute_line_line_intersections, a point that coincides
+    // with one line's own endpoint lands in improper_intersections, not
+    // proper_intersections, so this specifically exercises that category.
+    ShapeWithHoles s;
+    s.shape = build_shape({{0, 0}, {10, 0}, {10, 10}, {0, 10}});
+    Shape hole_2 = build_shape({{5, 7}, {5.5, 7.5}, {4.5, 7.5}});
+    s.holes = {
+        build_shape({{3, 3}, {7, 3}, {7, 7}, {5, 8, -1}, {3, 7}}),
+        hole_2,
+    };
+
+    BasicShapesDecomposition decomp = decompose_into_basic_shapes(s);
+
+    bool found_segment = false;
+    for (const BasicShape& basic_shape: decomp.basic_shapes) {
+        if (basic_shape.type != BasicShapeType::CircularSegment)
+            continue;
+        found_segment = true;
+        ASSERT_EQ(basic_shape.shape.elements.size(), 2);
+        const ShapeElement& chord = basic_shape.shape.elements[1];
+        // The chord must not even touch hole_2's boundary.
+        for (const ShapeElement& hole_2_element: hole_2.elements) {
+            ShapeElementIntersectionsOutput result = compute_intersections(chord, hole_2_element);
+            EXPECT_TRUE(result.proper_intersections.empty());
+            EXPECT_TRUE(result.improper_intersections.empty());
+            EXPECT_TRUE(result.overlapping_parts.empty());
+        }
+    }
+    EXPECT_TRUE(found_segment);
+}

--- a/test/no_fit_polygon_test.cpp
+++ b/test/no_fit_polygon_test.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 using namespace shape;
 
 
@@ -219,3 +221,186 @@ INSTANTIATE_TEST_SUITE_P(
         [](const testing::TestParamInfo<NoFitPolygonGeneralTest::ParamType>& info) {
             return info.param.name;
         });
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Convex overload with circular arcs (decompose_into_basic_shapes' circular
+// segments: one CircularArc element closed by its chord).
+//
+// No hand-derived expected shape here (impractical for arc geometry); these
+// are verified purely via the oracle grid-sampling check, same technique as
+// above: every point strictly inside the NFP must cause overlap when used to
+// translate orbiting_shape, and every point strictly outside must not.
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// A circular segment: arc from angle_1_deg to angle_2_deg (< 180 degrees
+// apart) around 'center' with 'radius', anticlockwise, closed by the chord
+// back to the arc's start -- exactly the shape decompose_into_basic_shapes
+// produces for a BasicShapeType::CircularSegment.
+Shape build_circular_segment(
+        Point center,
+        LengthDbl radius,
+        Angle angle_1_deg,
+        Angle angle_2_deg)
+{
+    Angle a1 = angle_1_deg * M_PI / 180.0;
+    Angle a2 = angle_2_deg * M_PI / 180.0;
+    Point p1 = {center.x + radius * std::cos(a1), center.y + radius * std::sin(a1)};
+    Point p2 = {center.x + radius * std::cos(a2), center.y + radius * std::sin(a2)};
+    Shape s;
+    s.elements.push_back(build_circular_arc(p1, p2, center, ShapeElementOrientation::Anticlockwise));
+    s.elements.push_back(build_line_segment(p2, p1));
+    return s;
+}
+
+}  // namespace
+
+struct NoFitPolygonArcOracleTestParams
+{
+    Shape fixed_shape;
+    Shape orbiting_shape;
+    std::string name;
+};
+
+std::ostream& operator<<(std::ostream& os, const NoFitPolygonArcOracleTestParams& params)
+{
+    os << params.name;
+    return os;
+}
+
+class NoFitPolygonArcOracleTest:
+    public testing::TestWithParam<NoFitPolygonArcOracleTestParams> { };
+
+TEST_P(NoFitPolygonArcOracleTest, NoFitPolygonArcOracle)
+{
+    NoFitPolygonArcOracleTestParams test_params = GetParam();
+    std::cout << "fixed_shape " << test_params.fixed_shape.to_string(0) << std::endl;
+    std::cout << "orbiting_shape " << test_params.orbiting_shape.to_string(0) << std::endl;
+
+    Shape nfp = no_fit_polygon(test_params.fixed_shape, test_params.orbiting_shape);
+    std::cout << "nfp " << nfp.to_string(0) << std::endl;
+
+    AxisAlignedBoundingBox aabb = nfp.compute_min_max();
+    const double margin = 0.5;
+    const double step = 0.2;
+    // Offset the grid off exact fractions of a degree / nice coordinates:
+    // sampling exactly on a shape boundary (e.g. at an arc's own extremal
+    // point) is a degenerate case for point-in-polygon ray casting that is
+    // not what this test is trying to exercise.
+    for (double px = aabb.x_min - margin + 0.0137; px <= aabb.x_max + margin; px += step) {
+        for (double py = aabb.y_min - margin + 0.0211; py <= aabb.y_max + margin; py += step) {
+            Point position = {px, py};
+
+            if (nfp.contains(position, /*strict=*/true)) {
+                Shape translated_orbiting = test_params.orbiting_shape;
+                translated_orbiting.shift(position.x, position.y);
+                EXPECT_TRUE(intersect(test_params.fixed_shape, translated_orbiting))
+                    << "Position (" << px << ", " << py << ") is inside the NFP "
+                    << "but the translated orbiting shape does not intersect the fixed shape.";
+            }
+            if (!nfp.contains(position, /*strict=*/false)) {
+                Shape translated_orbiting = test_params.orbiting_shape;
+                translated_orbiting.shift(position.x, position.y);
+                EXPECT_FALSE(intersect(test_params.fixed_shape, translated_orbiting))
+                    << "Position (" << px << ", " << py << ") is outside the NFP "
+                    << "but the translated orbiting shape intersects the fixed shape.";
+            }
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        Shape,
+        NoFitPolygonArcOracleTest,
+        testing::ValuesIn(std::vector<NoFitPolygonArcOracleTestParams>{
+            {  // Circular segment (no interaction needed with the square's edges).
+                build_circular_segment({0, 0}, 2.0, 10, 80),
+                build_rectangle(0, 1, 0, 1),
+                "SegmentAndSquare",
+            }, {  // A circular segment against itself: full arc-arc overlap
+                  // (the arc-arc "sum" path, both arcs identical).
+                build_circular_segment({0, 0}, 1.5, 20, 100),
+                build_circular_segment({0, 0}, 1.5, 20, 100),
+                "SegmentSelf",
+            }, {  // Two different-radius segments with partially overlapping
+                  // arc ranges: exercises peeling a lone prefix/suffix around
+                  // a summed middle range.
+                build_circular_segment({0, 0}, 1.0, 0, 90),
+                build_circular_segment({0, 0}, 2.0, 45, 135),
+                "SegmentsPartialOverlap",
+            }, {  // Two segments with disjoint (non-overlapping) arc ranges.
+                build_circular_segment({0, 0}, 1.0, 0, 60),
+                build_circular_segment({0, 0}, 1.0, 120, 170),
+                "SegmentsDisjointRanges",
+            }, {  // A wide (170 degree) segment against a triangle: one of
+                  // the triangle's edges falls squarely inside the arc's
+                  // span, forcing a reactive mid-arc split.
+                build_circular_segment({0, 0}, 1.5, 0, 170),
+                build_shape({{0, 0}, {2, 0}, {1, 2}}),
+                "WideSegmentAndTriangle",
+            }, {  // Segment as the orbiting shape instead of fixed (exercises
+                  // the negation path independently of which side has the arc).
+                build_shape({{0, 0}, {2, 0}, {1, 2}}),
+                build_circular_segment({0, 0}, 1.5, 0, 170),
+                "TriangleAndWideSegment",
+            },
+        }),
+        [](const testing::TestParamInfo<NoFitPolygonArcOracleTest::ParamType>& info) {
+            return info.param.name;
+        });
+
+
+////////////////////////////////////////////////////////////////////////////////
+// General overload with a rounded-corner shape, exercising
+// decompose_into_basic_shapes end-to-end (not just the convex-convex core).
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(NoFitPolygonGeneralArcTest, RoundedCornerSquare)
+{
+    // A 4x4 square with its top-right corner replaced by a quarter-circle
+    // fillet of radius 1.
+    Shape rounded;
+    rounded.elements.push_back(build_line_segment({0, 0}, {4, 0}));
+    rounded.elements.push_back(build_line_segment({4, 0}, {4, 3}));
+    rounded.elements.push_back(build_circular_arc(
+            {4, 3}, {3, 4}, {3, 3}, ShapeElementOrientation::Anticlockwise));
+    rounded.elements.push_back(build_line_segment({3, 4}, {0, 4}));
+    rounded.elements.push_back(build_line_segment({0, 4}, {0, 0}));
+    ShapeWithHoles fixed_shape{rounded, {}};
+    ShapeWithHoles orbiting_shape{build_rectangle(0, 1, 0, 1), {}};
+
+    MultiShapeWithHoles nfp = no_fit_polygon(fixed_shape, orbiting_shape);
+    std::cout << "nfp (" << nfp.shapes_with_holes.size() << " component(s))" << std::endl;
+    for (const ShapeWithHoles& component: nfp.shapes_with_holes)
+        std::cout << "  " << component.to_string(0) << std::endl;
+
+    ASSERT_EQ((ShapePos)nfp.shapes_with_holes.size(), (ShapePos)1);
+
+    AxisAlignedBoundingBox aabb = nfp.shapes_with_holes[0].compute_min_max();
+    const double margin = 0.5;
+    const double step = 0.2;
+    for (double px = aabb.x_min - margin + 0.0137; px <= aabb.x_max + margin; px += step) {
+        for (double py = aabb.y_min - margin + 0.0211; py <= aabb.y_max + margin; py += step) {
+            Point position = {px, py};
+            const ShapeWithHoles& component = nfp.shapes_with_holes[0];
+
+            if (component.contains(position, /*strict=*/true)) {
+                ShapeWithHoles translated_orbiting = orbiting_shape;
+                translated_orbiting.shift(position.x, position.y);
+                EXPECT_TRUE(intersect(fixed_shape.shape, translated_orbiting.shape))
+                    << "Position (" << px << ", " << py << ") is inside the NFP "
+                    << "but the translated orbiting shape does not intersect the fixed shape.";
+            }
+            if (!component.contains(position, /*strict=*/false)) {
+                ShapeWithHoles translated_orbiting = orbiting_shape;
+                translated_orbiting.shift(position.x, position.y);
+                EXPECT_FALSE(intersect(fixed_shape.shape, translated_orbiting.shape))
+                    << "Position (" << px << ", " << py << ") is outside the NFP "
+                    << "but the translated orbiting shape intersects the fixed shape.";
+            }
+        }
+    }
+}

--- a/test/shape_test.cpp
+++ b/test/shape_test.cpp
@@ -913,6 +913,29 @@ INSTANTIATE_TEST_SUITE_P(
             },
             ShapeContainsTestParams::read_json(
                     (fs::path("data") / "tests" / "shape" / "shape_contains" / "0.json").string()),
+            {
+                // A CircularArc whose *end* is exactly its own circle's
+                // topmost point (its tangent there is exactly horizontal),
+                // closed by a chord back to the arc's start. The horizontal
+                // ray used by the ray-casting algorithm for this query point
+                // is tangent to the arc exactly at that endpoint. The point
+                // queried here (-3, 1) is well outside this small shape
+                // (whose points all satisfy x in [0, 1], y in [0, 1]) but is
+                // currently reported as contained regardless of 'strict':
+                // CircularArc elements only exclude an intersection at their
+                // own start/end via a proper vs. improper distinction,
+                // unlike LineSegment elements (see the "Horizontal edges are
+                // excluded" special case in Shape::contains), so a ray
+                // tangent to an arc at exactly its topmost/bottommost point
+                // is miscounted.
+                build_shape({
+                        build_circular_arc({1, 0}, {0, 1}, {0, 0}, ShapeElementOrientation::Anticlockwise),
+                        build_line_segment({0, 1}, {1, 0}),
+                    }),
+                {-3, 1},
+                true,
+                false,
+            },
         }),
         [](const testing::TestParamInfo<ShapeContainsTest::ParamType>& info) {
             return std::to_string(info.index);


### PR DESCRIPTION
## Summary
- Add `decompose_into_basic_shapes`, decomposing a `ShapeWithHoles` into convex polygons and circular segments (a convex arc closed by its chord, plus the arc's circle for exact tangent-based separation).
- Support circular arcs directly in the `no_fit_polygon` convex-convex core: treat an arc as a continuous range of tangent directions, splitting arcs where the other shape's direction falls inside their span and summing overlapping arcs (Minkowski sum of two overlapping arcs is itself an arc: center = sum of centers, radius = sum of radii). The general (non-convex) overload now uses `decompose_into_basic_shapes` instead of `compute_convex_partition`, so arc-containing shapes work end-to-end.
- Fix `Shape::contains` for arcs tangent to the ray at start/end, where the tangent direction is undefined at the circle's topmost/bottommost point and previously defaulted to miscounting a mere tangent touch as a genuine crossing.
- Generalize the convex-convex core from at most one arc per shape to any number, removing the need for callers to pre-decompose shapes like an inflated convex polygon (every corner its own arc). Also fixes a latent tie-handling bug in the merge loop where `strictly_lesser_angle`'s zero-tolerance cross-product test spuriously broke ties between mathematically identical directions differing by ~1e-16 due to sqrt/trig noise.

## Test plan
- [x] `./build_claude/test/Shape_shape_test` — full suite passes
- [x] New oracle-verified `no_fit_polygon` test cases: segment vs polygon, self-NFP, overlapping/disjoint arc-arc, both orderings of arc vs polygon
- [x] New `ShapeContainsTest` repro for the tangent-at-extremum fix